### PR TITLE
Api cleanup: v1/cmd/batch endpoint

### DIFF
--- a/jmeter/juno_API_jmeter_test.jmx
+++ b/jmeter/juno_API_jmeter_test.jmx
@@ -197,6 +197,43 @@
           </RegexExtractor>
           <hashTree/>
         </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Run command" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&quot;payload&quot;:{&quot;data&quot;:&quot;&quot;,&quot;code&quot;:&quot;transfer(000-&gt;100-&gt;101-&gt;102-&gt;103-&gt;003, 100%1)&quot;},&quot;digest&quot;:{&quot;hash&quot;:&quot;h&quot;,&quot;key&quot;:&quot;b&quot;}}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8000</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/api/juno/v1/transact</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="CMDID -50 TSLA " enabled="true">
+            <stringProp name="RegexExtractor.useHeaders">unescaped</stringProp>
+            <stringProp name="RegexExtractor.refname">cmdid_4</stringProp>
+            <stringProp name="RegexExtractor.regex">.*&quot;cmdid&quot;:&quot;(\d*)&quot;.*</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default">NOT FOUND CMD1</stringProp>
+            <stringProp name="RegexExtractor.match_number"></stringProp>
+          </RegexExtractor>
+          <hashTree/>
+        </hashTree>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="QueryTX 1" enabled="true">
           <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments">

--- a/jmeter/juno_API_jmeter_test.jmx
+++ b/jmeter/juno_API_jmeter_test.jmx
@@ -307,7 +307,7 @@
             <stringProp name="ConstantTimer.delay">1000</stringProp>
           </ConstantTimer>
           <hashTree/>
-          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="poll cmds" enabled="true">
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="poll cmds after wait" enabled="true">
             <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
             <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
               <collectionProp name="Arguments.arguments">
@@ -334,7 +334,67 @@
             <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
           </HTTPSamplerProxy>
           <hashTree/>
+          <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+            <boolProp name="ResultCollector.error_logging">false</boolProp>
+            <objProp>
+              <name>saveConfig</name>
+              <value class="SampleSaveConfiguration">
+                <time>true</time>
+                <latency>true</latency>
+                <timestamp>true</timestamp>
+                <success>true</success>
+                <label>true</label>
+                <code>true</code>
+                <message>true</message>
+                <threadName>true</threadName>
+                <dataType>true</dataType>
+                <encoding>false</encoding>
+                <assertions>true</assertions>
+                <subresults>true</subresults>
+                <responseData>false</responseData>
+                <samplerData>false</samplerData>
+                <xml>false</xml>
+                <fieldNames>false</fieldNames>
+                <responseHeaders>false</responseHeaders>
+                <requestHeaders>false</requestHeaders>
+                <responseDataOnError>false</responseDataOnError>
+                <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+                <assertionsResultsToSave>0</assertionsResultsToSave>
+                <bytes>true</bytes>
+                <threadCounts>true</threadCounts>
+              </value>
+            </objProp>
+            <stringProp name="filename"></stringProp>
+          </ResultCollector>
+          <hashTree/>
         </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="poll empty cmds" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{ &quot;payload&quot;: { &quot;cmdids&quot;: [ &quot;&quot;, &quot;&quot;] }, &quot;digest&quot;: { &quot;hash&quot;: &quot;string&quot;, &quot;key&quot;: &quot;string&quot; } }</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8000</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/api/juno/v1/poll</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
         <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>

--- a/jmeter/run_batches.jmx
+++ b/jmeter/run_batches.jmx
@@ -43,7 +43,49 @@
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/api/juno/v1/accounts/adjust/batch</stringProp>
+          <stringProp name="HTTPSampler.path">/api/juno/v1/</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="CMDID -50 TSLA " enabled="true">
+            <stringProp name="RegexExtractor.useHeaders">unescaped</stringProp>
+            <stringProp name="RegexExtractor.refname">cmdid_4</stringProp>
+            <stringProp name="RegexExtractor.regex">.*&quot;cmdid&quot;:&quot;(\d*)&quot;.*</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default">NOT FOUND CMD1</stringProp>
+            <stringProp name="RegexExtractor.match_number"></stringProp>
+          </RegexExtractor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="TSLA batches" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&quot;payload&quot;:{&quot;cmds&quot;:&#xd;
+[&quot;{\&quot;account\&quot;:\&quot;WATER\&quot;}&quot;,&#xd;
+&quot;{\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&quot;{\&quot;amount\&quot;:100,\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&#xd;
+&quot;{\&quot;amount\&quot;:1000,\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&#xd;
+&quot;{\&quot;amount\&quot;:100,\&quot;account\&quot;:\&quot;KALE\&quot;}&quot;,&#xd;
+&quot;{\&quot;amount\&quot;:200,\&quot;account\&quot;:\&quot;KALE\&quot;}&quot;]},&quot;digest&quot;:{&quot;hash&quot;:&quot;hashy&quot;,&quot;key&quot;:&quot;mykey&quot;}}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8000</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/api/juno/v1/cmd/batch</stringProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/jmeter/run_batches.jmx
+++ b/jmeter/run_batches.jmx
@@ -26,44 +26,7 @@
         <stringProp name="ThreadGroup.delay"></stringProp>
       </ThreadGroup>
       <hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="TSLA batch" enabled="true">
-          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="" elementType="HTTPArgument">
-                <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{ &quot;payload&quot;: { &quot;account&quot;: &quot;TSLA&quot;, &quot;amount&quot;: 50.0 }, &quot;digest&quot;: { &quot;hash&quot;: &quot;myhash&quot;, &quot;key&quot;: &quot;string&quot; } }</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
-          </elementProp>
-          <stringProp name="HTTPSampler.domain">localhost</stringProp>
-          <stringProp name="HTTPSampler.port">8000</stringProp>
-          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-          <stringProp name="HTTPSampler.response_timeout"></stringProp>
-          <stringProp name="HTTPSampler.protocol"></stringProp>
-          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/api/juno/v1/</stringProp>
-          <stringProp name="HTTPSampler.method">POST</stringProp>
-          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-          <boolProp name="HTTPSampler.monitor">false</boolProp>
-          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-        </HTTPSamplerProxy>
-        <hashTree>
-          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="CMDID -50 TSLA " enabled="true">
-            <stringProp name="RegexExtractor.useHeaders">unescaped</stringProp>
-            <stringProp name="RegexExtractor.refname">cmdid_4</stringProp>
-            <stringProp name="RegexExtractor.regex">.*&quot;cmdid&quot;:&quot;(\d*)&quot;.*</stringProp>
-            <stringProp name="RegexExtractor.template">$1$</stringProp>
-            <stringProp name="RegexExtractor.default">NOT FOUND CMD1</stringProp>
-            <stringProp name="RegexExtractor.match_number"></stringProp>
-          </RegexExtractor>
-          <hashTree/>
-        </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="TSLA batches" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Multiple Commands" enabled="true">
           <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
             <collectionProp name="Arguments.arguments">
@@ -74,7 +37,8 @@
 &quot;{\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&quot;{\&quot;amount\&quot;:100,\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&#xd;
 &quot;{\&quot;amount\&quot;:1000,\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&#xd;
 &quot;{\&quot;amount\&quot;:100,\&quot;account\&quot;:\&quot;KALE\&quot;}&quot;,&#xd;
-&quot;{\&quot;amount\&quot;:200,\&quot;account\&quot;:\&quot;KALE\&quot;}&quot;]},&quot;digest&quot;:{&quot;hash&quot;:&quot;hashy&quot;,&quot;key&quot;:&quot;mykey&quot;}}</stringProp>
+&quot;{\&quot;amount\&quot;:200,\&quot;account\&quot;:\&quot;KALE\&quot;}&quot;,&#xd;
+&quot;{\&quot;data\&quot;:\&quot;\&quot;,\&quot;code\&quot;:\&quot;transfer(000-&gt;100-&gt;101-&gt;102-&gt;103-&gt;003, 100%1)\&quot;}&quot;]},&quot;digest&quot;:{&quot;hash&quot;:&quot;hashy&quot;,&quot;key&quot;:&quot;mykey&quot;}}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
             </collectionProp>

--- a/juno.cabal
+++ b/juno.cabal
@@ -23,6 +23,7 @@ library
                      , Apps.Juno.Command
                      , Apps.Juno.Client
                      , Apps.Juno.JsonTypes
+                     , Apps.Juno.ApiHandlers
                      , Apps.Juno.Ledger
                      , Apps.Juno.Parser
                      , Juno.Consensus.ByzRaft.Handler

--- a/src/Apps/Juno/ApiHandlers.hs
+++ b/src/Apps/Juno/ApiHandlers.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Apps.Juno.ApiHandlers (
+                            createAccount
+                           ,adjustAccount
+                           ,transactAPI
+                           ,ledgerQueryAPI
+                           ,cmdBatch
+                           ) where
+
+import           Control.Concurrent.Chan.Unagi
+import           Control.Monad.IO.Class (liftIO)
+
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.Text as T
+import           Data.Maybe (catMaybes)
+
+import           Snap.Core
+import           Data.Aeson (encode)
+import qualified Data.Aeson as JSON
+
+import           Apps.Juno.JsonTypes
+import           Juno.Runtime.Types hiding (CommandBatch)
+import           Juno.Consensus.ByzRaft.Client (
+                                                CommandMVarMap
+                                               ,setNextCmdRequestId
+                                               )
+
+
+import           Apps.Juno.Ledger
+
+apiWrapper :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap ->  (BLC.ByteString -> Either BLC.ByteString [CommandEntry]) -> Snap ()
+apiWrapper toCommands cmdStatusMap requestHandler = do
+   modifyResponse $ setHeader "Content-Type" "application/json"
+   reqBytes <- (readRequestBody 1000000)
+   case (requestHandler reqBytes) of
+     Right cmdEntries -> do
+         reqestId@(RequestId rId) <- liftIO $ setNextCmdRequestId cmdStatusMap
+         liftIO $ writeChan toCommands (reqestId, cmdEntries)
+         (writeBS . BLC.toStrict . JSON.encode) $ commandResponseSuccess ((T.pack . show) rId) ""
+     Left err -> (writeBS . BLC.toStrict) $ err
+
+-- create an account returns cmdId see: juno/jmeter/juno_API_jmeter_test.jmx
+createAccount :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
+createAccount toCommands cmdStatusMap =
+    apiWrapper toCommands cmdStatusMap createAccountReqHandler
+
+-- Adjusts Account (negative, positive) returns cmdIds: juno/jmeter/juno_API_jmeter_test.jmx
+adjustAccount :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
+adjustAccount toCommands cmdStatusMap =
+    apiWrapper toCommands cmdStatusMap adjustAccoutReqHandler
+
+-- juno/jmeter/juno_API_jmeter_test.jmx
+-- accept hopercommands transfer(000->100->101->102->103->003, 100%1)
+transactAPI :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
+transactAPI toCommands cmdStatusMap =
+   apiWrapper toCommands cmdStatusMap transactReqHandler
+
+ledgerQueryAPI :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
+ledgerQueryAPI toCommands cmdStatusMap =
+    apiWrapper toCommands cmdStatusMap ledgerQueryReqHandler
+
+-- receives a list of commands
+-- {"payload":{"cmds": ["{\"account\":\"WATER\"}", "{\"account\":\"TSLA\"}"},"digest":{"hash":"hashy","key":"mykey"}}
+cmdBatch :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
+cmdBatch toCommands cmdStatusMap =
+    apiWrapper toCommands cmdStatusMap cmdBatchHandler
+
+
+-- | Handlers to deal with the incomming request bytes and either create the correct
+--   [ComandEntry] ByteString or the JSON error message ByteString
+createAccountReqHandler :: BLC.ByteString -> Either BLC.ByteString [CommandEntry]
+createAccountReqHandler bs =
+     case (JSON.decode bs) of
+       Just (CreateAccountRequest (AccountPayload acct) _) ->
+           Right [CommandEntry $ createAccountBS' $ T.unpack acct]
+       Nothing ->
+           Left $ (JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON.")
+ where
+   createAccountBS' acct = BSC.pack $ "CreateAccount " ++ acct
+
+adjustAccoutReqHandler :: BLC.ByteString -> Either BLC.ByteString [CommandEntry]
+adjustAccoutReqHandler bs =
+  case (JSON.decode bs) of
+     Just (AccountAdjustRequest (AccountAdjustPayload acct amt) _) ->
+         Right [CommandEntry $ adjustAccountBS acct amt]
+     Nothing ->
+         Left $ (JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON.")
+ where
+  adjustAccountBS acct amt = BSC.pack $ "AdjustAccount " ++ T.unpack acct ++ " " ++ show (toRational amt)
+
+transactReqHandler :: BLC.ByteString -> Either BLC.ByteString [CommandEntry]
+transactReqHandler bs =
+    case (JSON.decode bs) of
+      Just (TransactRequest (TransactBody code body) _) ->
+          Right [CommandEntry $ BSC.pack $ T.unpack code]
+      Nothing ->
+          Left $ (JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON.")
+
+ledgerQueryReqHandler :: BLC.ByteString -> Either BLC.ByteString [CommandEntry]
+ledgerQueryReqHandler bs =
+    case (JSON.decode bs) of
+      Just (LedgerQueryRequest (LedgerQueryBody (QueryJson acct tx sender receiver)) _) -> do
+         let mByBoth = (ByAcctName Both) <$> acct
+         let mSwiftId =  BySwiftId <$> tx
+         let mBySender = (ByAcctName Sender) <$> sender
+         let mByReceiver = (ByAcctName Receiver) <$> receiver
+         let query = And $ catMaybes [ mSwiftId, mBySender, mByReceiver, mByBoth ]
+         Right $[CommandEntry $ BLC.toStrict $ encode query]
+      Nothing ->
+         Left $ (JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON.")
+
+cmdBatchHandler :: BLC.ByteString -> Either BLC.ByteString [CommandEntry]
+cmdBatchHandler bs =
+    case (JSON.decode bs) of
+      Just (CommandBatchRequest (CommandBatch cmds) _) ->
+        -- or catMaybes depending if one fails, all fail?
+        case (sequence $ fmap (mJsonBsToCommand . BLC.pack . T.unpack) cmds) of
+          Just cmds' -> Right $ fmap CommandEntry cmds'
+          Nothing -> Left errorBadCommand
+      Nothing -> Left errorBadCommandBatch
+ where
+   errorBadCommand = JSON.encode $ commandResponseFailure "" "Malformed cmd or cmds in the submitted batch, could not decode input JSON."
+   errorBadCommandBatch = JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON."

--- a/src/Apps/Juno/Client.hs
+++ b/src/Apps/Juno/Client.hs
@@ -43,6 +43,7 @@ import Juno.Runtime.Types (CommandEntry(..),CommandResult(..),CommandStatus(..),
 import Juno.Consensus.ByzRaft.Client (CommandMVarMap, CommandMap(..), initCommandMap, setNextCmdRequestId)
 
 import Apps.Juno.JsonTypes
+import Apps.Juno.ApiHandlers
 import Apps.Juno.Parser
 import Apps.Juno.Ledger
 
@@ -121,113 +122,17 @@ snapServer :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> IO ()
 snapServer toCommands cmdStatusMap = httpServe serverConf $
     applyCORS defaultOptions $ methods [GET, POST]
     (ifTop (writeBS "use /hopper for commands") <|>
-     route [ ("/api/juno/v1/accounts/create", createAccounts toCommands cmdStatusMap)
-           , ("/api/juno/v1/accounts/adjust", adjustAccounts toCommands cmdStatusMap)
-           , ("/api/juno/v1/accounts/adjust/batch", adjustAccountsBatchTest toCommands cmdStatusMap)
-           , ("/api/juno/v1/cmd/batch", cmdBatch toCommands cmdStatusMap)
+     route [ ("/api/juno/v1/accounts/create", createAccount toCommands cmdStatusMap)
+           , ("/api/juno/v1/accounts/adjust", adjustAccount toCommands cmdStatusMap)
            , ("/api/juno/v1/transact", transactAPI toCommands cmdStatusMap)
-           , ("/api/juno/v1/poll", pollForResults cmdStatusMap)
            , ("/api/juno/v1/query", ledgerQueryAPI toCommands cmdStatusMap)
+           , ("/api/juno/v1/cmd/batch", cmdBatch toCommands cmdStatusMap)
+           , ("/api/juno/v1/poll", pollForResults cmdStatusMap)
            , ("hopper", hopperHandler toCommands cmdStatusMap)
            , ("swift", swiftHandler toCommands cmdStatusMap)
            , ("api/swift-submit", swiftSubmission toCommands cmdStatusMap)
            , ("api/ledger-query", ledgerQuery toCommands cmdStatusMap)
            ])
-
--- create an account returns cmdId see: juno/jmeter/juno_API_jmeter_test.jmx
-createAccounts :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
-createAccounts toCommands cmdStatusMap = do
-    maybeCreateAccount <- liftM JSON.decode (readRequestBody 1000)
-    modifyResponse $ setHeader "Content-Type" "application/json"
-    case maybeCreateAccount of
-      Just (CreateAccountRequest (AccountPayload acct) _) -> do
-        reqestId@(RequestId rId) <- liftIO $ setNextCmdRequestId cmdStatusMap
-        liftIO $ writeChan toCommands (reqestId, [CommandEntry $ createAccountBS' $ T.unpack acct])
-        -- byz/client updates successfully
-        (writeBS . BL.toStrict . JSON.encode) $ commandResponseSuccess ((T.pack . show) rId) ""
-      Nothing -> writeBS . BL.toStrict . JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON."
-  where
-    createAccountBS' acct = BSC.pack $ "CreateAccount " ++ acct
-
--- juno/jmeter/juno_API_jmeter_test.jmx
--- accept hopercommands transfer(000->100->101->102->103->003, 100%1)
-transactAPI :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
-transactAPI toCommands cmdStatusMap = do
-   maybeTx <- liftM JSON.decode (readRequestBody 1000)
-   modifyResponse $ setHeader "Content-Type" "application/json"
-   case maybeTx of
-     Just (TransactRequest (TransactBody code body) _) -> do
-         reqestId@(RequestId rId) <- liftIO $ setNextCmdRequestId cmdStatusMap
-         liftIO $ writeChan toCommands (reqestId, [CommandEntry $ BSC.pack $ T.unpack code])
-         (writeBS . BL.toStrict . JSON.encode) $
-                commandResponseSuccess ((T.pack . show) rId) ""
-     Nothing -> writeBS . BL.toStrict . JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON."
-
--- Adjusts Account (negative, positive) returns cmdIds: juno/jmeter/juno_API_jmeter_test.jmx
-adjustAccounts :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
-adjustAccounts toCommands cmdStatusMap = do
-   maybeAdjustAccount <- liftM JSON.decode (readRequestBody 1000)
-   modifyResponse $ setHeader "Content-Type" "application/json"
-   case maybeAdjustAccount of
-     Just (AccountAdjustRequest (AccountAdjustPayload acct amt) _) -> do
-         reqestId@(RequestId rId) <- liftIO $ setNextCmdRequestId cmdStatusMap
-         liftIO $ writeChan toCommands (reqestId, [CommandEntry $ adjustAccountBS acct amt])
-         (writeBS . BL.toStrict . JSON.encode) $ commandResponseSuccess ((T.pack . show) rId) ""
-     Nothing -> writeBS . BL.toStrict . JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON."
-     where
-       adjustAccountBS acct amt = BSC.pack $ "AdjustAccount " ++ T.unpack acct ++ " " ++ show (toRational amt)
-
--- Adjusts Account (negative, positive) returns cmdIds: juno/jmeter/juno_API_jmeter_test.jmx
-adjustAccountsBatchTest :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
-adjustAccountsBatchTest toCommands cmdStatusMap = do
-   maybeAdjustAccount <- liftM JSON.decode (readRequestBody 1000)
-   modifyResponse $ setHeader "Content-Type" "application/json"
-   case maybeAdjustAccount of
-     Just (AccountAdjustRequest (AccountAdjustPayload acct amt) _) -> do
-         reqestId@(RequestId rId) <- liftIO $ setNextCmdRequestId cmdStatusMap
-         let adjustBatch = take 40 $ (repeat $ adjustAccountCommand acct amt)
-         liftIO $ writeChan toCommands (reqestId, adjustBatch)
-         (writeBS . BL.toStrict . JSON.encode) $ commandResponseSuccess ((T.pack . show) rId) ""
-     Nothing -> writeBS . BL.toStrict . JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON."
-  where
-       adjustAccountCommand acct amt = CommandEntry $ BSC.pack $ "AdjustAccount " ++ T.unpack acct ++ " " ++ show (toRational amt)
-
--- receives a list of commands
--- {"payload":{"cmds": ["{\"account\":\"WATER\"}", "{\"account\":\"TSLA\"}"},"digest":{"hash":"hashy","key":"mykey"}}
-cmdBatch :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
-cmdBatch toCommands cmdStatusMap = do
-   modifyResponse $ setHeader "Content-Type" "application/json"
-   maybeCmdBatchReq <- liftM JSON.decode (readRequestBody 1000000)
-   case maybeCmdBatchReq of
-     Just (CommandBatchRequest (CommandBatch cmds) _) -> do
-         reqestId@(RequestId rId) <- liftIO $ setNextCmdRequestId cmdStatusMap
-         -- or catMaybes depending if one fails, all fail?
-         case (sequence $ fmap (mJsonBsToCommand . BLC.pack . T.unpack) cmds) of
-           Just cmds' -> do
-             liftIO $ writeChan toCommands (reqestId, fmap CommandEntry cmds')
-             (writeBS . BL.toStrict . JSON.encode) $ commandResponseSuccess ((T.pack . show) rId) ""
-           Nothing -> errorBadCommand
-
-     Nothing -> errorBadCommandBatch
-  where
-    errorBadCommand = (writeBS . BL.toStrict . JSON.encode) $ commandResponseFailure "" "Malformed cmd or cmds in the submitted batch, could not decode input JSON."
-    errorBadCommandBatch = writeBS . BL.toStrict . JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON."
-
-ledgerQueryAPI :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
-ledgerQueryAPI toCommands cmdStatusMap = do
-   maybeQuery <- liftM JSON.decode (readRequestBody 100000)
-   modifyResponse $ setHeader "Content-Type" "application/json"
-   case maybeQuery of
-     Just (LedgerQueryRequest (LedgerQueryBody (QueryJson acct tx sender receiver)) _) -> do
-         let mByBoth = (ByAcctName Both) <$> acct
-         let mSwiftId =  BySwiftId <$> tx
-         let mBySender = (ByAcctName Sender) <$> sender
-         let mByReceiver = (ByAcctName Receiver) <$> receiver
-         reqestId@(RequestId rId) <- liftIO $ setNextCmdRequestId cmdStatusMap
-         let query = And $ catMaybes [ mSwiftId, mBySender, mByReceiver, mByBoth ]
-         liftIO $ writeChan toCommands (reqestId, [CommandEntry $ BLC.toStrict $ encode query])
-         (writeBS . BL.toStrict . JSON.encode) $ commandResponseSuccess ((T.pack . show) rId) ""
-     Nothing -> writeBS . BL.toStrict . JSON.encode $ commandResponseFailure "" (T.pack $ "Malformed input, could not decode input JSON.")
 
 -- poll for a list of cmdIds, returning the applied results or error
 -- see juno/jmeter/juno_API_jmeter_test.jmx
@@ -238,11 +143,13 @@ pollForResults cmdStatusMap = do
   case maybePoll of
     Just (PollPayloadRequest (PollPayload cmdids) _) -> do
       (CommandMap _ m) <- liftIO $ readMVar cmdStatusMap
-      let rids = fmap (RequestId . read . T.unpack) cmdids
+      let rids = fmap (RequestId . read . T.unpack) $ cleanInput cmdids
       let results = PollResponse $ fmap (toRepresentation . flipIt m) rids
       writeBS . BL.toStrict $ JSON.encode results
     Nothing -> writeBS . BL.toStrict . JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON."
  where
+   -- for now allow "" cmdIds
+   cleanInput = filter (/=T.empty)
 
    flipIt :: Map RequestId CommandStatus ->  RequestId -> Maybe (RequestId, CommandStatus)
    flipIt m rId = (fmap . fmap) (\cmd -> (rId, cmd)) (`Map.lookup` m) rId

--- a/src/Apps/Juno/JsonTypes.hs
+++ b/src/Apps/Juno/JsonTypes.hs
@@ -5,13 +5,16 @@
 module Apps.Juno.JsonTypes where
 
 import           Control.Monad (mzero)
-import           Data.Aeson (genericParseJSON,genericToJSON,parseJSON,toJSON,ToJSON,FromJSON,Value(..))
+import           Data.Aeson as JSON
 import           Data.Text.Encoding (decodeUtf8)
-import           Data.Aeson.Types (defaultOptions,object,Options(..),(.:),(.=))
+import           Data.Aeson.Types (Options(..),defaultOptions)
 import qualified Data.Text as T
 import           Data.Text (Text)
 import           GHC.Generics
 import           Juno.Runtime.Types (CommandStatus(..),CommandResult(..),RequestId(..))
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import           Control.Applicative
 
 removeUnderscore :: String -> String
 removeUnderscore = drop 1
@@ -221,8 +224,7 @@ instance FromJSON LedgerQueryRequest where
 --   "hash": "string",
 --   "key": "string"
 -- }
---
---
+
 data TransactBody = TransactBody { _txCode :: Text, _txData :: Text } deriving (Show, Eq)
 instance ToJSON TransactBody where
     toJSON (TransactBody code txData) = object ["code" .= code, "data" .= txData]
@@ -242,5 +244,54 @@ instance FromJSON TransactRequest where
                                            <*> v .: "digest"
     parseJSON _ = mzero
 
--- test
---txBS = "{\"payload\":{\"data\":\"mybody\",\"code\":\"mycode\"},\"digest\":{\"hash\":\"hashy\",\"key\":\"key\"}}"
+-- {
+-- "payload": {
+--   "cmds": ["string"]
+-- },
+-- "digest": {
+--   "hash": "string",
+--   "key": "string"
+-- }
+data CommandBatch = CommandBatch {
+      _batchCmds :: [Text]
+    } deriving (Eq,Show,Ord)
+
+instance ToJSON CommandBatch where
+    toJSON (CommandBatch cmds) = object ["cmds" .= cmds]
+instance FromJSON CommandBatch where
+     parseJSON (Object v) = CommandBatch <$> v .: "cmds"
+     parseJSON _ = mzero
+
+data CommandBatchRequest = CommandBatchRequest {
+      cmdBatchpayload :: CommandBatch,
+      cmdBatchdigest :: Digest
+    } deriving (Show, Generic, Eq)
+
+instance ToJSON CommandBatchRequest where
+  toJSON (CommandBatchRequest payload' digest') = object ["payload" .= payload', "digest" .= digest']
+instance FromJSON CommandBatchRequest where
+  parseJSON (Object v) = CommandBatchRequest <$> v .: "payload"
+                                             <*> v .: "digest"
+  parseJSON _ = mzero
+
+mJsonBsToCommand :: BLC.ByteString -> Maybe BSC.ByteString
+mJsonBsToCommand bs = mAdjustAccount <|>
+                      mAdjustCreateAcct <|>
+                      mtransact
+  where
+    mAdjustAccount = case JSON.decode bs of
+                       Just (AccountAdjustPayload acct amt) ->
+                         Just $ BSC.pack $
+                          "AdjustAccount " ++  T.unpack acct ++ " " ++ show (toRational amt)
+                       _ -> Nothing
+
+    mAdjustCreateAcct = case JSON.decode bs of
+                         Just (AccountPayload acct) ->
+                             Just $ BSC.pack $
+                               "CreateAccount " ++  T.unpack acct
+                         _ -> Nothing
+
+    mtransact = case JSON.decode bs of
+                  Just (TransactBody code _) ->
+                      Just $ BSC.pack $ T.unpack code
+                  _ -> Nothing


### PR DESCRIPTION
Adding a transact endpoint to support a list of commands, and breaking out API functions into their own module, adding an API wrapper function to encapsulate repeated code request handling.