### PR TITLE
API breakout from juno consensus

### DIFF
--- a/conf/10000-cluster.yaml
+++ b/conf/10000-cluster.yaml
@@ -15,6 +15,18 @@ publicKeys:
 heartbeatTimeout: 1500000
 clientPublicKeys:
 - - host: '127.0.0.1'
+    port: 10000
+  - adc1fa8f4f6f14e0687ab9e78e75775214ff186c33cf5bdc5db7db90fb471c9b
+- - host: '127.0.0.1'
+    port: 10001
+  - 5b7409cc34ac8bffd82ab3b995ad639ac879417d86c8ed42b1d293d556b665c9
+- - host: '127.0.0.1'
+    port: 10002
+  - a1adc20b14c602925dd3c7ab4f2ead58d140139cbbfd659fc80b7e5ae7b8919d
+- - host: '127.0.0.1'
+    port: 10003
+  - 6c498a90e2cfc6f75cfd521d24f487a2e073f68439d409e65375bd03e05b099a
+- - host: '127.0.0.1'
     port: 10004
   - 3b0761012bcea5b6335427260294ea38e35725142ba08b8ffddbf36c9dc5a5d1
 electionTimeoutRange:

--- a/conf/10001-cluster.yaml
+++ b/conf/10001-cluster.yaml
@@ -15,6 +15,18 @@ publicKeys:
 heartbeatTimeout: 1500000
 clientPublicKeys:
 - - host: '127.0.0.1'
+    port: 10000
+  - adc1fa8f4f6f14e0687ab9e78e75775214ff186c33cf5bdc5db7db90fb471c9b
+- - host: '127.0.0.1'
+    port: 10001
+  - 5b7409cc34ac8bffd82ab3b995ad639ac879417d86c8ed42b1d293d556b665c9
+- - host: '127.0.0.1'
+    port: 10002
+  - a1adc20b14c602925dd3c7ab4f2ead58d140139cbbfd659fc80b7e5ae7b8919d
+- - host: '127.0.0.1'
+    port: 10003
+  - 6c498a90e2cfc6f75cfd521d24f487a2e073f68439d409e65375bd03e05b099a
+- - host: '127.0.0.1'
     port: 10004
   - 3b0761012bcea5b6335427260294ea38e35725142ba08b8ffddbf36c9dc5a5d1
 electionTimeoutRange:

--- a/conf/10002-cluster.yaml
+++ b/conf/10002-cluster.yaml
@@ -15,6 +15,18 @@ publicKeys:
 heartbeatTimeout: 1500000
 clientPublicKeys:
 - - host: '127.0.0.1'
+    port: 10000
+  - adc1fa8f4f6f14e0687ab9e78e75775214ff186c33cf5bdc5db7db90fb471c9b
+- - host: '127.0.0.1'
+    port: 10001
+  - 5b7409cc34ac8bffd82ab3b995ad639ac879417d86c8ed42b1d293d556b665c9
+- - host: '127.0.0.1'
+    port: 10002
+  - a1adc20b14c602925dd3c7ab4f2ead58d140139cbbfd659fc80b7e5ae7b8919d
+- - host: '127.0.0.1'
+    port: 10003
+  - 6c498a90e2cfc6f75cfd521d24f487a2e073f68439d409e65375bd03e05b099a
+- - host: '127.0.0.1'
     port: 10004
   - 3b0761012bcea5b6335427260294ea38e35725142ba08b8ffddbf36c9dc5a5d1
 electionTimeoutRange:

--- a/conf/10003-cluster.yaml
+++ b/conf/10003-cluster.yaml
@@ -15,6 +15,18 @@ publicKeys:
 heartbeatTimeout: 1500000
 clientPublicKeys:
 - - host: '127.0.0.1'
+    port: 10000
+  - adc1fa8f4f6f14e0687ab9e78e75775214ff186c33cf5bdc5db7db90fb471c9b
+- - host: '127.0.0.1'
+    port: 10001
+  - 5b7409cc34ac8bffd82ab3b995ad639ac879417d86c8ed42b1d293d556b665c9
+- - host: '127.0.0.1'
+    port: 10002
+  - a1adc20b14c602925dd3c7ab4f2ead58d140139cbbfd659fc80b7e5ae7b8919d
+- - host: '127.0.0.1'
+    port: 10003
+  - 6c498a90e2cfc6f75cfd521d24f487a2e073f68439d409e65375bd03e05b099a
+- - host: '127.0.0.1'
     port: 10004
   - 3b0761012bcea5b6335427260294ea38e35725142ba08b8ffddbf36c9dc5a5d1
 electionTimeoutRange:

--- a/conf/10004-client.yaml
+++ b/conf/10004-client.yaml
@@ -15,6 +15,9 @@ publicKeys:
 heartbeatTimeout: 1500000
 clientPublicKeys:
 - - host: '127.0.0.1'
+    port: 10003
+  - 6c498a90e2cfc6f75cfd521d24f487a2e073f68439d409e65375bd03e05b099a
+- - host: '127.0.0.1'
     port: 10004
   - 3b0761012bcea5b6335427260294ea38e35725142ba08b8ffddbf36c9dc5a5d1
 electionTimeoutRange:

--- a/executables/GenerateConfigFiles.hs
+++ b/executables/GenerateConfigFiles.hs
@@ -6,6 +6,7 @@ import Data.Ratio
 import Crypto.Ed25519.Pure
 import Text.Read
 import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 import Data.Thyme.Clock
 import System.IO
 import System.FilePath

--- a/juno.cabal
+++ b/juno.cabal
@@ -26,6 +26,7 @@ library
                      , Apps.Juno.ApiHandlers
                      , Apps.Juno.Ledger
                      , Apps.Juno.Parser
+                     , Juno.Consensus.ByzRaft.Api
                      , Juno.Consensus.ByzRaft.Handler
                      , Juno.Consensus.ByzRaft.Server
                      , Juno.Consensus.ByzRaft.Client
@@ -49,6 +50,7 @@ library
                      , Juno.Messaging.ZMQ
                      , Juno.Monitoring.Server
                      , Juno.Persistence.SQLite
+                     , Juno.Runtime.Api.ApiServer
                      , Juno.Runtime.Log
                      , Juno.Runtime.MessageReceiver
                      , Juno.Runtime.Role

--- a/juno.cabal
+++ b/juno.cabal
@@ -55,6 +55,7 @@ library
                      , Juno.Runtime.Sender
                      , Juno.Runtime.Timer
                      , Juno.Runtime.Types
+                     , Juno.Runtime.Protocol.Types
                      , Juno.Spec.Simple
                      , Juno.Util.Combinator
                      , Juno.Util.Util

--- a/src/Apps/Juno/ApiHandlers.hs
+++ b/src/Apps/Juno/ApiHandlers.hs
@@ -12,22 +12,29 @@ module Apps.Juno.ApiHandlers (
 
 import           Control.Concurrent.Chan.Unagi
 import           Control.Concurrent.MVar (readMVar)
+import           Control.Concurrent.Lifted (threadDelay)
+import           Control.Lens hiding ((.=))
+import           Control.Monad.Reader
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Text as T
+import           Data.List (intercalate)
 import           Data.Maybe (catMaybes)
 import qualified Data.Map as Map
 import           Data.Map (Map)
-
-import           Snap.Core
-import           Data.Aeson (encode)
+import           Data.Monoid ((<>))
+import           Data.Text.Encoding (decodeUtf8)
+import           Data.Ratio
+import           Data.Aeson (encode, object, (.=))
 import qualified Data.Aeson as JSON
+import           Snap.Core
 
 import           Apps.Juno.JsonTypes
-import           Juno.Runtime.Types hiding (CommandBatch)
-
 import           Apps.Juno.Ledger
-import           Control.Monad.Reader
+import           Apps.Juno.Parser
+import           Juno.Runtime.Types hiding (CommandBatch)
+import           Schwifty.Swift.M105.Types
+import           Schwifty.Swift.M105.Parser
 
 data ApiEnv = ApiEnv {
       _toCommands :: InChan (RequestId, [CommandEntry]),
@@ -36,12 +43,17 @@ data ApiEnv = ApiEnv {
 
 apiRoutes :: ReaderT ApiEnv Snap ()
 apiRoutes = route [
-              ("/accounts/create", createAccount)
-             ,("/accounts/adjust", adjustAccount)
-             ,("/transact", transactAPI)
-             ,("/query", ledgerQueryAPI)
-             ,("/cmd/batch", cmdBatch)
-             ,("/poll", pollForResults)
+              ("api/juno/v1/accounts/create", createAccount)
+             ,("api/juno/v1/accounts/adjust", adjustAccount)
+             ,("api/juno/v1/transact", transactAPI)
+             ,("api/juno/v1/query", ledgerQueryAPI)
+             ,("api/juno/v1/cmd/batch", cmdBatch)
+             ,("api/juno/v1/poll", pollForResults)
+              -- original API
+             ,("hopper", hopperHandler)
+             ,("swift", swiftHandler)
+             ,("api/swift-submit", swiftSubmission)
+             ,("api/ledger-query", ledgerQuery)
              ]
 
 apiWrapper :: (BLC.ByteString -> Either BLC.ByteString [CommandEntry]) -> ReaderT ApiEnv Snap ()
@@ -160,3 +172,115 @@ pollForResults = do
    toRepresentation (Just (RequestId rid, cmdStatus)) =
        cmdStatus2PollResult (RequestId rid) cmdStatus
    toRepresentation Nothing = cmdStatusError
+
+
+---
+swiftSubmission :: ReaderT ApiEnv Snap ()
+swiftSubmission = do
+  (ApiEnv toCommands cmdStatusMap) <- ask
+  bdy <- readRequestBody 1000000
+  cmd <- return $ BLC.toStrict bdy
+  logError $ "swiftSubmission: " <> cmd
+  let unparsedSwift = decodeUtf8 cmd
+  case parseSwift unparsedSwift of
+    -- TODO: get to work with `errDone 400 $`
+    Left err ->
+        writeBS $ BLC.toStrict $ encode $
+                object ["status" .= ("Failure" :: T.Text), "reason" .= err]
+    Right v -> do
+      -- TODO: maybe the swift blob should be serialized vs json-ified
+      let blob = SwiftBlob unparsedSwift $ swiftToHopper v
+      rId <- liftIO $ setNextCmdRequestId cmdStatusMap
+      liftIO $ writeChan toCommands (rId, [CommandEntry $ BLC.toStrict $ encode blob])
+      resp <- liftIO $ waitForCommand cmdStatusMap rId
+      logError $ "swiftSubmission: " <> resp
+      modifyResponse $ setHeader "Content-Type" "application/json"
+      writeBS resp
+
+ledgerQuery :: ReaderT ApiEnv Snap ()
+ledgerQuery = do
+  (ApiEnv toCommands cmdStatusMap) <- ask
+  mBySwift <- fmap BySwiftId <$> getIntegerParam "tx"
+  mBySender <- fmap (ByAcctName Sender) <$> getTextParam "sender"
+  mByReceiver <- fmap (ByAcctName Receiver) <$> getTextParam "receiver"
+  mByBoth <- fmap (ByAcctName Both) <$> getTextParam "account"
+  let query = And $ catMaybes [mBySwift, mBySender, mByReceiver, mByBoth]
+  -- TODO: if you are querying the ledger should we wait for the command to be applied here?
+  rId <- liftIO $ setNextCmdRequestId cmdStatusMap
+  liftIO $ writeChan toCommands (rId, [CommandEntry $ BLC.toStrict $ encode query])
+  resp <- liftIO $ waitForCommand cmdStatusMap rId
+  modifyResponse $ setHeader "Content-Type" "application/json"
+  writeBS resp
+
+  where
+    getIntegerParam p = (>>= fmap fst . BSC.readInteger) <$> getQueryParam p
+    getTextParam p = fmap decodeUtf8 <$> getQueryParam p
+
+swiftHandler :: ReaderT ApiEnv Snap ()
+swiftHandler = do
+  (ApiEnv toCommands cmdStatusMap) <- ask
+  bdy <- readRequestBody 1000000
+  cmd <- return $ BLC.toStrict bdy
+  logError $ "swiftHandler: " <> cmd
+  case parseSwift $ decodeUtf8 cmd of
+     -- TODO: get to work with `errDone 400 $`
+    Left err -> writeBS $ BLC.toStrict $ encode $
+                object ["status" .= ("Failure" :: T.Text), "reason" .= err]
+    Right v -> do
+        rId <- liftIO $ setNextCmdRequestId cmdStatusMap
+        liftIO $ writeChan toCommands (rId, [CommandEntry $ BSC.pack (swiftToHopper v)])
+        resp <- liftIO $ waitForCommand cmdStatusMap rId
+        modifyResponse $ setHeader "Content-Type" "application/json"
+        logError $ "swiftHandler: SUCCESS: " <> resp
+        writeBS resp
+
+
+errDone :: Int -> BSC.ByteString -> Snap ()
+errDone c bs = logError bs >> writeBS bs >> withResponse (finishWith . setResponseCode c)
+
+swiftToHopper :: SWIFT -> String
+swiftToHopper m = hopperProgram to' from' inter' amt'
+  where
+    to' :: String
+    to' = T.unpack $ view (sCode59a . bcAccount) m
+    from' :: String
+    from' = T.unpack $ dirtyPickOutAccount50a m
+    intermediaries :: [String]
+    intermediaries = ["100","101","102","103"]
+    branchA2BranchB = intercalate "->" intermediaries
+    branchB2BranchA = intercalate "->" (reverse intermediaries)
+    det71a = view sCode71A m
+    inter' = case det71a of
+               Beneficiary -> branchB2BranchA
+               _ -> branchA2BranchB
+    amt' :: Ratio Int
+    amt' = fromIntegral (view (sCode32A . vcsSettlementAmount . vWhole) m) + view (sCode32A . vcsSettlementAmount . vPart) m
+    hopperProgram :: String -> String -> String -> Ratio Int -> String
+    hopperProgram t f i a = "transfer(" ++ f ++ "->" ++ i ++ "->" ++ t ++ "," ++ show a ++ ")"
+
+hopperHandler :: ReaderT ApiEnv Snap ()
+hopperHandler = do
+    (ApiEnv toCommands cmdStatusMap) <- ask
+    bdy <- readRequestBody 1000000
+    logError $ "hopper: " <> BLC.toStrict bdy
+    cmd <- return $ BLC.toStrict bdy
+    case readHopper cmd of
+      -- TODO: get to work with `errDone 400 $`
+      Left err -> writeBS $ BSC.pack err
+      Right _ -> do
+        rId <- liftIO $ setNextCmdRequestId cmdStatusMap
+        liftIO $ writeChan toCommands (rId, [CommandEntry cmd])
+        resp <- liftIO $ waitForCommand cmdStatusMap rId
+        writeBS resp
+
+-- wait for the command to be present in the MVar (used by hopperHandler, swiftHandler, etc.)
+waitForCommand :: CommandMVarMap -> RequestId -> IO BSC.ByteString
+waitForCommand cmdMap rId =
+    threadDelay 1000 >> do
+      (CommandMap _ m) <- readMVar cmdMap
+      case Map.lookup rId m of
+        Nothing -> return $ BSC.pack $ "RequestId [" ++ show rId ++ "] not found."
+        Just (CmdApplied (CommandResult bs)) ->
+          return $ bs
+        Just _ -> -- not applied yet, loop and wait
+          waitForCommand cmdMap rId

--- a/src/Apps/Juno/ApiHandlers.hs
+++ b/src/Apps/Juno/ApiHandlers.hs
@@ -25,15 +25,9 @@ import qualified Data.Aeson as JSON
 
 import           Apps.Juno.JsonTypes
 import           Juno.Runtime.Types hiding (CommandBatch)
-import           Juno.Consensus.ByzRaft.Client (
-                                                CommandMVarMap
-                                               ,setNextCmdRequestId
-                                               )
-
 
 import           Apps.Juno.Ledger
 import           Control.Monad.Reader
-import           Juno.Consensus.ByzRaft.Client (CommandMap(..))
 
 data ApiEnv = ApiEnv {
       _toCommands :: InChan (RequestId, [CommandEntry]),

--- a/src/Apps/Juno/Client.hs
+++ b/src/Apps/Juno/Client.hs
@@ -5,41 +5,23 @@ module Apps.Juno.Client
   ) where
 
 import Control.Concurrent.Chan.Unagi
-import Control.Applicative
 import Control.Concurrent.Lifted (threadDelay)
 import Control.Monad.Reader
 
 import Data.Either ()
-import Data.Maybe (catMaybes)
 import System.IO
 
-import qualified Data.ByteString.Lazy.Char8 as BLC
 import qualified Data.ByteString.Char8 as BSC
-import Data.Text.Encoding (decodeUtf8)
-import qualified Data.Text as T
-import Snap.Http.Server
-import Snap.Core
-import Control.Lens hiding ((.=))
-import Data.Ratio
-import Data.Aeson (encode, object, (.=))
 
-import Snap.CORS
-import Data.List
 import Text.Read (readMaybe)
-import Data.Monoid
 import qualified Data.Map as Map
 import           Control.Concurrent.MVar
 import qualified Control.Concurrent.Lifted as CL
 
-import Schwifty.Swift.M105.Types
-import Schwifty.Swift.M105.Parser
-
 import Juno.Spec.Simple
 import Juno.Runtime.Types
 
-import Apps.Juno.ApiHandlers
 import Apps.Juno.Parser
-import Apps.Juno.Ledger
 
 prompt :: String
 prompt = "\ESC[0;31mhopper>> \ESC[0m"
@@ -52,18 +34,6 @@ flushStr str = putStr str >> hFlush stdout
 
 readPrompt :: IO String
 readPrompt = flushStr prompt >> getLine
-
--- wait for the command to be present in the MVar (used by hopperHandler, swiftHandler, etc.)
-waitForCommand :: CommandMVarMap -> RequestId -> IO BSC.ByteString
-waitForCommand cmdMap rId =
-    threadDelay 1000 >> do
-      (CommandMap _ m) <- readMVar cmdMap
-      case Map.lookup rId m of
-        Nothing -> return $ BSC.pack $ "RequestId [" ++ show rId ++ "] not found."
-        Just (CmdApplied (CommandResult bs)) ->
-          return $ bs
-        Just _ -> -- not applied yet, loop and wait
-          waitForCommand cmdMap rId
 
 -- should we poll here till we get a result?
 showResult :: CommandMVarMap -> RequestId -> IO ()
@@ -108,108 +78,6 @@ runREPL toCommands cmdStatusMap = do
             writeChan toCommands (rId, [CommandEntry cmd'])
             showResult cmdStatusMap rId
             runREPL toCommands cmdStatusMap
-
-serverConf :: MonadSnap m => Config m a
-serverConf = setErrorLog (ConfigFileLog "log/error.log") $ setAccessLog (ConfigFileLog "log/access.log") defaultConfig
-
-snapServer :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> IO ()
-snapServer toCommands cmdStatusMap = httpServe serverConf $
-    applyCORS defaultOptions $ methods [GET, POST]
-    (ifTop (writeBS "use /hopper for commands") <|>
-     route [ ("/api/juno/v1", runReaderT apiRoutes (ApiEnv toCommands cmdStatusMap))
-           , ("hopper", hopperHandler toCommands cmdStatusMap)
-           , ("swift", swiftHandler toCommands cmdStatusMap)
-           , ("api/swift-submit", swiftSubmission toCommands cmdStatusMap)
-           , ("api/ledger-query", ledgerQuery toCommands cmdStatusMap)
-           ])
-
-swiftSubmission :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
-swiftSubmission toCommands cmdStatusMap = do
-  bdy <- readRequestBody 1000000
-  cmd <- return $ BLC.toStrict bdy
-  logError $ "swiftSubmission: " <> cmd
-  let unparsedSwift = decodeUtf8 cmd
-  case parseSwift unparsedSwift of
-    Left err -> errDone 400 $ BLC.toStrict $ encode $ object ["status" .= ("Failure" :: T.Text), "reason" .= err]
-    Right v -> do
-      -- TODO: maybe the swift blob should be serialized vs json-ified
-      let blob = SwiftBlob unparsedSwift $ swiftToHopper v
-      rId <- liftIO $ setNextCmdRequestId cmdStatusMap
-      liftIO $ writeChan toCommands (rId, [CommandEntry $ BLC.toStrict $ encode blob])
-      resp <- liftIO $ waitForCommand cmdStatusMap rId
-      logError $ "swiftSubmission: " <> resp
-      modifyResponse $ setHeader "Content-Type" "application/json"
-      writeBS resp
-
-ledgerQuery :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
-ledgerQuery toCommands cmdStatusMap = do
-  mBySwift <- fmap BySwiftId <$> getIntegerParam "tx"
-  mBySender <- fmap (ByAcctName Sender) <$> getTextParam "sender"
-  mByReceiver <- fmap (ByAcctName Receiver) <$> getTextParam "receiver"
-  mByBoth <- fmap (ByAcctName Both) <$> getTextParam "account"
-  let query = And $ catMaybes [mBySwift, mBySender, mByReceiver, mByBoth]
-  -- TODO: if you are querying the ledger should we wait for the command to be applied here?
-  rId <- liftIO $ setNextCmdRequestId cmdStatusMap
-  liftIO $ writeChan toCommands (rId, [CommandEntry $ BLC.toStrict $ encode query])
-  resp <- liftIO $ waitForCommand cmdStatusMap rId
-  modifyResponse $ setHeader "Content-Type" "application/json"
-  writeBS resp
-
-  where
-    getIntegerParam p = (>>= fmap fst . BSC.readInteger) <$> getQueryParam p
-    getTextParam p = fmap decodeUtf8 <$> getQueryParam p
-
-swiftHandler :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
-swiftHandler toCommands cmdStatusMap = do
-  bdy <- readRequestBody 1000000
-  cmd <- return $ BLC.toStrict bdy
-  logError $ "swiftHandler: " <> cmd
-  case parseSwift $ decodeUtf8 cmd of
-    Left err -> errDone 400 $ BLC.toStrict $ encode $ object ["status" .= ("Failure" :: T.Text), "reason" .= err]
-    Right v -> do
-        rId <- liftIO $ setNextCmdRequestId cmdStatusMap
-        liftIO $ writeChan toCommands (rId, [CommandEntry $ BSC.pack (swiftToHopper v)])
-        resp <- liftIO $ waitForCommand cmdStatusMap rId
-        modifyResponse $ setHeader "Content-Type" "application/json"
-        logError $ "swiftHandler: SUCCESS: " <> resp
-        writeBS resp
-
-
-errDone :: Int -> BSC.ByteString -> Snap ()
-errDone c bs = logError bs >> writeBS bs >> withResponse (finishWith . setResponseCode c)
-
-swiftToHopper :: SWIFT -> String
-swiftToHopper m = hopperProgram to' from' inter' amt'
-  where
-    to' :: String
-    to' = T.unpack $ view (sCode59a . bcAccount) m
-    from' :: String
-    from' = T.unpack $ dirtyPickOutAccount50a m
-    intermediaries :: [String]
-    intermediaries = ["100","101","102","103"]
-    branchA2BranchB = intercalate "->" intermediaries
-    branchB2BranchA = intercalate "->" (reverse intermediaries)
-    det71a = view sCode71A m
-    inter' = case det71a of
-               Beneficiary -> branchB2BranchA
-               _ -> branchA2BranchB
-    amt' :: Ratio Int
-    amt' = fromIntegral (view (sCode32A . vcsSettlementAmount . vWhole) m) + view (sCode32A . vcsSettlementAmount . vPart) m
-    hopperProgram :: String -> String -> String -> Ratio Int -> String
-    hopperProgram t f i a = "transfer(" ++ f ++ "->" ++ i ++ "->" ++ t ++ "," ++ show a ++ ")"
-
-hopperHandler :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Snap ()
-hopperHandler toCommands cmdStatusMap = do
-    bdy <- readRequestBody 1000000
-    logError $ "hopper: " <> BLC.toStrict bdy
-    cmd <- return $ BLC.toStrict bdy
-    case readHopper cmd of
-      Left err -> errDone 400 $ BSC.pack err
-      Right _ -> do
-        rId <- liftIO $ setNextCmdRequestId cmdStatusMap
-        liftIO $ writeChan toCommands (rId, [CommandEntry cmd])
-        resp <- liftIO $ waitForCommand cmdStatusMap rId
-        writeBS resp
 
 -- | Runs a 'Raft nt String String mt'.
 -- Simple fixes nt to 'HostPort' and mt to 'String'.

--- a/src/Apps/Juno/Client.hs
+++ b/src/Apps/Juno/Client.hs
@@ -35,8 +35,7 @@ import Schwifty.Swift.M105.Types
 import Schwifty.Swift.M105.Parser
 
 import Juno.Spec.Simple
-import Juno.Runtime.Types (CommandEntry(..),CommandResult(..),CommandStatus(..))
-import Juno.Consensus.ByzRaft.Client (CommandMVarMap, CommandMap(..), initCommandMap, setNextCmdRequestId)
+import Juno.Runtime.Types
 
 import Apps.Juno.ApiHandlers
 import Apps.Juno.Parser
@@ -220,7 +219,6 @@ main = do
   -- `toResult` is unused. There seem to be API's that use/block on fromResult.
   -- Either we need to kill this channel full stop or `toResult` needs to be used.
   cmdStatusMap <- initCommandMap
-  void $ CL.fork $ snapServer toCommands cmdStatusMap
   let -- getEntry :: (IO et)
       getEntries :: IO (RequestId, [CommandEntry])
       getEntries = readChan fromCommands

--- a/src/Juno/Consensus/ByzRaft/Api.hs
+++ b/src/Juno/Consensus/ByzRaft/Api.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Juno.Consensus.ByzRaft.Api
+  ( apiReceiver
+  ) where
+
+import           Control.Lens
+import qualified Data.Set as Set
+import           Control.Monad
+import           Juno.Runtime.Types
+import           Juno.Runtime.Protocol.Types
+import           Juno.Util.Util
+import           Juno.Runtime.Timer
+
+import qualified Data.Map as Map
+import qualified Data.ByteString.Char8 as SB8
+import           Control.Monad.RWS
+import           Text.Read (readMaybe)
+import           Control.Concurrent (takeMVar, putMVar, modifyMVar_)
+import           Juno.Runtime.Sender (sendRPC)
+
+-- TODO do we need all this? can we just enqueueEvent directly?
+-- get commands with getEntry and put them on the event queue to be sent
+-- THREAD: CLIENT COMMAND
+apiReceiver :: MonadIO m => Raft m ()
+apiReceiver = do
+  nid <- view (cfg.nodeId)
+  forever $ do
+    cmdMap <- view (rs.cmdStatusMap)
+    (rid@(RequestId _), cmdEntries) <- dequeueCommand
+    -- support for special REPL command "> batch test:5000", runs hardcoded batch job
+    cmds' <- case cmdEntries of
+               (CommandEntry cmd):[] | SB8.take 11 cmd == "batch test:" -> do
+                                          let missiles = take (batchSize cmd) $ repeat $ hardcodedTransfers nid cmdMap
+                                          liftIO $ sequence $ missiles
+               _ -> liftIO $ sequence $ fmap ((nextRid nid) cmdMap) cmdEntries
+    -- set current requestId in Raft to the value associated with this request.
+    rid' <- setNextRequestId' rid
+    liftIO (modifyMVar_ cmdMap (\(CommandMap n m) -> return $ CommandMap n (Map.insert rid CmdAccepted m)))
+    -- hack set the head to the org rid
+    let cmds'' = case cmds' of
+                   ((Command entry nid' _ NewMsg):rest) -> (Command entry nid' rid' NewMsg):rest
+                   _ -> []
+    -- TODO: have the client really sign this and map the client digest to this.
+    --       for now, node 1003 has keys registered as client and protocol node.
+    clientSendCommandBatch' $ CommandBatch cmds'' NewMsg
+  where
+    batchSize :: (Num c, Read c) => SB8.ByteString -> c
+    batchSize cmd = maybe 500 id . readMaybe $ drop 11 $ SB8.unpack cmd
+
+    nextRid :: NodeID -> CommandMVarMap -> CommandEntry -> IO Command
+    nextRid nid cmdMap entry = do
+      rid <- (setNextCmdRequestId' cmdMap)
+      return (Command entry nid rid NewMsg)
+
+    hardcodedTransfers :: NodeID -> CommandMVarMap-> IO Command
+    hardcodedTransfers nid cmdMap = nextRid nid cmdMap transferCmdEntry
+
+    transferCmdEntry :: CommandEntry
+    transferCmdEntry = (CommandEntry "transfer(Acct1->Acct2, 1 % 1)")
+
+-- move to utils, this is the only CommandStatus that should inc the requestId
+-- NB: this only works when we have a single client, but punting on solving this for now is a good idea.
+-- TODO add Mac or node ID to the requestID for now.
+setNextCmdRequestId' :: CommandMVarMap -> IO RequestId
+setNextCmdRequestId' cmdMapMvar = do
+  (CommandMap nextId m) <- takeMVar cmdMapMvar
+  putMVar cmdMapMvar $ CommandMap (nextId + 1) (Map.insert nextId CmdSubmitted m)
+  return nextId
+
+-- This should be broken now? This node might not be the leader.
+setNextRequestId' :: Monad m => RequestId -> Raft m RequestId
+setNextRequestId' rid = do
+  currentRequestId .= rid
+  use currentRequestId
+
+-- | Always send CommandBatches, a single Command is a batch of size 1.
+-- Sends to the leader, knows the leader because running in Raft
+-- THREAD: CLIENT MAIN. updates state
+clientSendCommandBatch' :: Monad m => CommandBatch -> Raft m ()
+clientSendCommandBatch' cmdb@CommandBatch{..} = do
+  mlid <- use currentLeader
+  case mlid of
+    Just lid -> do
+      sendRPC lid $ CMDB' cmdb
+      prcount <- fmap Map.size (use pendingRequests)
+      -- if this will be our only pending request, start the timer
+      -- otherwise, it should already be running
+      let lastCmd = last _cmdbBatch
+      when (prcount == 0) resetHeartbeatTimer
+      pendingRequests %= Map.insert (_cmdRequestId lastCmd) lastCmd -- TODO should we update CommandMap here?
+    Nothing  -> do
+      setLeaderToFirst' -- TODO: do we need this anymore? The raft protocol should be taking care of this as well.
+      clientSendCommandBatch' cmdb
+
+-- THREAD: CLIENT MAIN. updates state
+-- If the client doesn't know the leader? Then set leader to first node, the client will be updated with the real leaderId when it receives a command response.
+setLeaderToFirst' :: Monad m => Raft m ()
+setLeaderToFirst' = do
+  nodes <- view (cfg.otherNodes)
+  when (Set.null nodes) $ error "the client has no nodes to send requests to"
+  setCurrentLeader $ Just $ Set.findMin nodes
+
+-- TODO: remove these (still in Client.hs)
+--       this only need to be command related, there should not longer be code
+--       for handling other events, this is done by the protocol.
+-- THREAD: CLIENT MAIN. updates state.
+setLeaderToNext' :: Monad m => Raft m ()
+setLeaderToNext' = do
+  mlid <- use currentLeader
+  nodes <- view (cfg.otherNodes)
+  case mlid of
+    Just lid -> case Set.lookupGT lid nodes of
+      Just nlid -> setCurrentLeader $ Just nlid
+      Nothing   -> setLeaderToFirst'
+    Nothing -> setLeaderToFirst'

--- a/src/Juno/Consensus/ByzRaft/Commit.hs
+++ b/src/Juno/Consensus/ByzRaft/Commit.hs
@@ -19,6 +19,7 @@ import qualified Data.Map as Map
 import Data.Foldable (toList)
 
 import Juno.Runtime.Types hiding (valid)
+import Juno.Runtime.Protocol.Types
 import Juno.Util.Util
 import Juno.Runtime.Sender (sendResults)
 import Juno.Runtime.Log

--- a/src/Juno/Consensus/ByzRaft/Handler.hs
+++ b/src/Juno/Consensus/ByzRaft/Handler.hs
@@ -9,6 +9,7 @@ import Control.Monad
 import Data.Maybe
 
 import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 import Juno.Runtime.Log
 import Juno.Consensus.ByzRaft.Commit (doCommit)
 import Juno.Runtime.Sender (sendAllAppendEntries,sendAllAppendEntriesResponse)

--- a/src/Juno/Consensus/ByzRaft/Server.hs
+++ b/src/Juno/Consensus/ByzRaft/Server.hs
@@ -6,6 +6,7 @@ import Control.Lens
 import qualified Data.Set as Set
 
 import Juno.Consensus.ByzRaft.Handler
+import Juno.Consensus.ByzRaft.Api (apiReceiver)
 import Juno.Runtime.Protocol.Types
 import Juno.Util.Util
 import Juno.Runtime.Timer
@@ -28,5 +29,6 @@ raft :: Raft IO ()
 raft = do
   logStaticMetrics
   void $ CL.fork messageReceiver -- THREAD: SERVER MESSAGE RECEIVER
+  void $ CL.fork apiReceiver     -- THREAD: waits for cmds from API, signs and sends to leader.
   resetElectionTimer
   handleEvents

--- a/src/Juno/Consensus/ByzRaft/Server.hs
+++ b/src/Juno/Consensus/ByzRaft/Server.hs
@@ -6,7 +6,7 @@ import Control.Lens
 import qualified Data.Set as Set
 
 import Juno.Consensus.ByzRaft.Handler
-import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 import Juno.Util.Util
 import Juno.Runtime.Timer
 import Juno.Runtime.MessageReceiver

--- a/src/Juno/Consensus/Pure/Handle/AppendEntries.hs
+++ b/src/Juno/Consensus/Pure/Handle/AppendEntries.hs
@@ -22,7 +22,7 @@ import Juno.Consensus.Pure.Handle.AppendEntriesResponse (updateCommitProofMap)
 import Juno.Runtime.Sender (sendAllAppendEntriesResponse, sendAppendEntriesResponse, createAppendEntriesResponse)
 import Juno.Runtime.Timer (resetElectionTimer)
 import Juno.Util.Util
-import qualified Juno.Runtime.Types as JT
+import qualified Juno.Runtime.Protocol.Types as JT
 import Juno.Runtime.Log
 
 data AppendEntriesEnv = AppendEntriesEnv {

--- a/src/Juno/Consensus/Pure/Handle/AppendEntriesResponse.hs
+++ b/src/Juno/Consensus/Pure/Handle/AppendEntriesResponse.hs
@@ -26,7 +26,7 @@ import Juno.Consensus.Pure.Types
 
 import Juno.Runtime.Timer (resetElectionTimerLeader)
 import Juno.Util.Util (debug, updateLNextIndex)
-import qualified Juno.Runtime.Types as JT
+import qualified Juno.Runtime.Protocol.Types as JT
 
 data AEResponseEnv = AEResponseEnv {
 -- Old Constructors

--- a/src/Juno/Consensus/Pure/Handle/Command.hs
+++ b/src/Juno/Consensus/Pure/Handle/Command.hs
@@ -21,8 +21,7 @@ import Juno.Consensus.Pure.Types
 import Juno.Runtime.Sender (sendRPC, createAppendEntriesResponse)
 import Juno.Util.Util (getCmdSigOrInvariantError)
 
-import qualified Juno.Runtime.Types as JT
-
+import qualified Juno.Runtime.Protocol.Types as JT
 
 data CommandEnv = CommandEnv {
       _role :: Role

--- a/src/Juno/Consensus/Pure/Handle/ElectionTimeout.hs
+++ b/src/Juno/Consensus/Pure/Handle/ElectionTimeout.hs
@@ -20,7 +20,7 @@ import Juno.Runtime.Timer (resetElectionTimer, hasElectionTimerLeaderFired)
 import Juno.Util.Combinator ((^$))
 import Juno.Util.Util
 import Juno.Runtime.Log
-import qualified Juno.Runtime.Types as JT
+import qualified Juno.Runtime.Protocol.Types as JT
 
 data ElectionTimeoutEnv = ElectionTimeoutEnv {
       _role :: Role

--- a/src/Juno/Consensus/Pure/Handle/HeartbeatTimeout.hs
+++ b/src/Juno/Consensus/Pure/Handle/HeartbeatTimeout.hs
@@ -15,7 +15,7 @@ import Juno.Consensus.Pure.Types
 import Juno.Runtime.Sender (sendAllAppendEntries)
 import Juno.Runtime.Timer (resetHeartbeatTimer, hasElectionTimerLeaderFired)
 import Juno.Util.Util (debug,enqueueEvent)
-import qualified Juno.Runtime.Types as JT
+import qualified Juno.Runtime.Protocol.Types as JT
 
 data HeartbeatTimeoutEnv = HeartbeatTimeoutEnv {
       _role :: Role

--- a/src/Juno/Consensus/Pure/Handle/RequestVote.hs
+++ b/src/Juno/Consensus/Pure/Handle/RequestVote.hs
@@ -18,7 +18,7 @@ import Juno.Runtime.Log
 
 import Juno.Consensus.Pure.Types
 
-import qualified Juno.Runtime.Types as JT
+import qualified Juno.Runtime.Protocol.Types as JT
 
 data RequestVoteEnv = RequestVoteEnv {
 -- Old Constructors

--- a/src/Juno/Consensus/Pure/Handle/RequestVoteResponse.hs
+++ b/src/Juno/Consensus/Pure/Handle/RequestVoteResponse.hs
@@ -19,7 +19,7 @@ import Juno.Runtime.Timer (resetHeartbeatTimer, resetElectionTimerLeader,
                            resetElectionTimer)
 import Juno.Util.Util
 import Juno.Runtime.Log
-import qualified Juno.Runtime.Types as JT
+import qualified Juno.Runtime.Protocol.Types as JT
 
 data RequestVoteResponseEnv = RequestVoteResponseEnv {
       _role :: Role

--- a/src/Juno/Consensus/Pure/Handle/Revolution.hs
+++ b/src/Juno/Consensus/Pure/Handle/Revolution.hs
@@ -15,7 +15,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Juno.Consensus.Pure.Types
 import Juno.Util.Util (debug, getRevSigOrInvariantError)
-import qualified Juno.Runtime.Types as JT
+import qualified Juno.Runtime.Protocol.Types as JT
 
 data RevolutionEnv = RevolutionEnv {
     _lazyVote         :: Maybe (Term, NodeID, LogIndex) -- Handler

--- a/src/Juno/Consensus/Pure/Types.hs
+++ b/src/Juno/Consensus/Pure/Types.hs
@@ -32,4 +32,5 @@ module Juno.Consensus.Pure.Types (
   ) where
 
 
+import Juno.Runtime.Protocol.Types
 import Juno.Runtime.Types

--- a/src/Juno/Messaging/ZMQ.hs
+++ b/src/Juno/Messaging/ZMQ.hs
@@ -19,7 +19,8 @@ import Data.Thyme.Clock
 import Data.Serialize
 
 import Juno.Messaging.Types
-import Juno.Runtime.Types (ReceivedAt(..),SignedRPC(..),Digest(..),MsgType(..))
+import Juno.Runtime.Types (ReceivedAt(..),Digest(..),MsgType(..))
+import Juno.Runtime.Protocol.Types (SignedRPC(..))
 
 sendProcess :: OutChan (OutBoundMsg String ByteString)
             -> Rolodex String (Socket z Push)

--- a/src/Juno/Monitoring/Server.hs
+++ b/src/Juno/Monitoring/Server.hs
@@ -5,8 +5,8 @@ module Juno.Monitoring.Server
   ( startMonitoring
   ) where
 
-import Juno.Runtime.Types (Config, Metric(..), LogIndex(..), Term(..),
-                           NodeID(..), nodeId, _port)
+import Juno.Runtime.Protocol.Types (Config, nodeId, Metric(..), LogIndex(..), Term(..))
+import Juno.Runtime.Types (NodeID(..), _port)
 
 import Juno.Monitoring.EkgMonitor (Server, forkServer, getLabel, getGauge,
                                  getDistribution)

--- a/src/Juno/Persistence/SQLite.hs
+++ b/src/Juno/Persistence/SQLite.hs
@@ -18,6 +18,7 @@ import Data.ByteString hiding (concat)
 import qualified Data.Text as T
 
 import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 
 -- These live here as orphans, and not in Types, because trying to Serialize these things should be a type level error
 -- with rare exception (i.e. for hashing the log entry). Moreover, accidentally sending Provenance over the wire could

--- a/src/Juno/Runtime/Api/ApiServer.hs
+++ b/src/Juno/Runtime/Api/ApiServer.hs
@@ -10,7 +10,7 @@ module Juno.Runtime.Api.ApiServer (runApiServer) where
 --   * check status of command, i.e. communication between API server and Raft (MVar for now, but this could be redis or another key value store running on every node
 --   * Parse Commands, and change CommandEntry -> [Command (with nodeId)] .. should this happen here? Or should that be in the protocol?
 
-import           Juno.Runtime.Types hiding (Config)
+import           Juno.Runtime.Types
 
 import           Apps.Juno.ApiHandlers
 import           Control.Applicative
@@ -40,7 +40,7 @@ snapApiServer :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Int -> 
 snapApiServer toCommands cmdStatusMap port = httpServe (serverConf port) $
     applyCORS (defaultOptions) $ methods [GET, POST]
     (ifTop (writeBS "use /hopper for commands") <|>
-     route [ ("/api/juno/v1", runReaderT apiRoutes (ApiEnv toCommands cmdStatusMap))]
+     route [ ("/", runReaderT apiRoutes (ApiEnv toCommands cmdStatusMap))] -- api/juno/v1
     )
 
 serverConf :: MonadSnap m => Int -> Config m a

--- a/src/Juno/Runtime/Api/ApiServer.hs
+++ b/src/Juno/Runtime/Api/ApiServer.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Juno.Runtime.Api.ApiServer (runApiServer) where
+
+-- | Api server is the interface between outside clients
+--   and the internal Juno/Raft protocol.
+--   Responible for:
+--   * listening for incoming Commands
+--   * managing RequestId
+--   * check status of command, i.e. communication between API server and Raft (MVar for now, but this could be redis or another key value store running on every node
+--   * Parse Commands, and change CommandEntry -> [Command (with nodeId)] .. should this happen here? Or should that be in the protocol?
+
+import           Juno.Runtime.Types hiding (Config)
+
+import           Apps.Juno.ApiHandlers
+import           Control.Applicative
+import           Control.Concurrent.Chan.Unagi
+import           Control.Monad.Reader
+
+import           Snap.Http.Server
+import           Snap.Core
+import           Snap.CORS
+
+-- |
+-- Starts the API server which will listen on a port for incoming client
+-- commands (raw commands are written to the `toCommands` channel) in the form:
+-- `"AdjustAccount " ++ T.unpack acct ++ " " ++ show (toRational amt)`.
+-- The Juno / raft protocol will be initialized with out/read side of the
+-- this channel, and is responisble for putting the data in the correct
+-- format for the protocol. For now when querying the only shared item
+-- sharedCmdStatusMap
+runApiServer :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Int -> IO ()
+runApiServer toCommands sharedCmdStatusMap port = do
+  putStrLn "Starting up server runApiServer"
+  snapApiServer toCommands sharedCmdStatusMap port
+  putStrLn "Server Started"
+
+-- TODO removed from App/client
+snapApiServer :: InChan (RequestId, [CommandEntry]) -> CommandMVarMap -> Int -> IO ()
+snapApiServer toCommands cmdStatusMap port = httpServe (serverConf port) $
+    applyCORS (defaultOptions) $ methods [GET, POST]
+    (ifTop (writeBS "use /hopper for commands") <|>
+     route [ ("/api/juno/v1", runReaderT apiRoutes (ApiEnv toCommands cmdStatusMap))]
+    )
+
+serverConf :: MonadSnap m => Int -> Config m a
+serverConf port = setErrorLog (ConfigFileLog "log/error.log") $ setAccessLog (ConfigFileLog "log/access.log") $ setPort port $ defaultConfig

--- a/src/Juno/Runtime/Log.hs
+++ b/src/Juno/Runtime/Log.hs
@@ -9,6 +9,7 @@ module Juno.Runtime.Log
     ) where
 
 import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 import Control.Lens
 import Data.ByteString (ByteString)
 import qualified Data.Sequence as Seq

--- a/src/Juno/Runtime/MessageReceiver.hs
+++ b/src/Juno/Runtime/MessageReceiver.hs
@@ -16,6 +16,7 @@ import qualified Data.Serialize as S
 import qualified Data.Set as Set
 
 import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 import Juno.Util.Util (debugNoRole,enqueueEvent)
 
 

--- a/src/Juno/Runtime/Protocol/Types.hs
+++ b/src/Juno/Runtime/Protocol/Types.hs
@@ -1,0 +1,711 @@
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Juno.Runtime.Protocol.Types
+--
+-- Holds the core Juno/Raft Types used to implement BFT Raft
+-- the types here are internal to the protocol nodes, but for now they share
+-- some types Runtime/Types.hs with Api/Types.hs.
+
+module Juno.Runtime.Protocol.Types
+  ( Raft
+  , RaftSpec(..)
+  , readLogEntry, writeLogEntry, readTermNumber, writeTermNumber
+  , readVotedFor, writeVotedFor, applyLogEntry, sendMessage
+  , sendMessages, getMessage, getMessages, getNewCommands, getNewEvidence
+  , debugPrint, publishMetric, getTimestamp, random
+  , enqueue, enqueueMultiple, dequeue, enqueueLater, killEnqueued
+  , NodeID(..)
+  , CommandEntry(..)
+  , CommandResult(..)
+  , CommandStatus(..)
+  , Term(..), startTerm
+  , LogIndex(..), startIndex
+  , RequestId(..), startRequestId, toRequestId
+  , Config(..), otherNodes, nodeId, electionTimeoutRange, heartbeatTimeout
+  , enableDebug, publicKeys, clientPublicKeys, myPrivateKey, clientTimeoutLimit
+  , myPublicKey, batchTimeDelta
+  , Role(..)
+  , Metric(..)
+  , RaftEnv(..), cfg, clusterSize, quorumSize, rs
+  , LogEntry(..), leTerm, leCommand, leHash
+  , Log(..), lEntries
+  , RaftState(..), role, term, votedFor, lazyVote, currentLeader, ignoreLeader
+  , logEntries, commitIndex, commitProof, lastApplied, timerThread, replayMap
+  , cYesVotes, cPotentialVotes, lNextIndex, lMatchIndex, lConvinced
+  , lastCommitTime, numTimeouts, pendingRequests, currentRequestId
+  , timeSinceLastAER, lLastBatchUpdate
+  , initialRaftState
+  -- * RPC
+  , AppendEntries(..)
+  , AppendEntriesResponse(..), AERWire(..), AlotOfAERs(..)
+  , RequestVote(..)
+  , RequestVoteResponse(..)
+  , Command(..)
+  , CommandResponse(..)
+  , CommandBatch(..)
+  , Revolution(..)
+  , RPC(..)
+  , Event(..)
+  , KeySet(..), WireFormat(..)
+  , signedRPCtoRPC, rpcToSignedRPC
+  , SignedRPC(..)
+  -- for simplicity, re-export some core types that we need all over the place
+  , PublicKey, PrivateKey, Signature(..), sign, valid, importPublic, importPrivate
+  -- for testing & benchmarks
+  , LEWire(..), encodeLEWire, decodeLEWire, decodeRVRWire
+  , verifySignedRPC, CMDWire(..)
+  ) where
+
+import Control.Monad (mzero)
+import Control.Parallel.Strategies
+import Control.Concurrent (ThreadId)
+import Control.Lens hiding (Index, (|>))
+import qualified Control.Lens as Lens
+import Control.Monad.RWS (RWST)
+--import Crypto.Ed25519.Pure ( PublicKey, PrivateKey, Signature(..), sign, valid
+--                           , importPublic, importPrivate, exportPublic, exportPrivate)
+import Data.Sequence (Seq, (|>))
+import qualified Data.Sequence as Seq
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.ByteString (ByteString)
+import Data.Serialize (Serialize)
+import qualified Data.Serialize as S
+import Data.Foldable
+import Text.Read (readMaybe)
+import qualified Data.Text as Text
+import Data.Thyme.Clock
+import Data.Thyme.Time.Core ()
+
+import Data.Aeson (genericParseJSON,genericToJSON,parseJSON,toJSON,ToJSON,FromJSON,Value(..))
+import Data.Aeson.Types (defaultOptions,Options(..))
+
+import GHC.Generics hiding (from)
+
+import System.Random (Random)
+import Juno.Runtime.Types
+
+newtype Term = Term Int
+  deriving (Show, Read, Eq, Enum, Num, Ord, Generic, Serialize)
+
+startTerm :: Term
+startTerm = Term (-1)
+
+newtype LogIndex = LogIndex Int
+  deriving (Show, Read, Eq, Ord, Enum, Num, Real, Integral, Generic, Serialize)
+
+startIndex :: LogIndex
+startIndex = LogIndex (-1)
+
+data Config = Config
+  { _otherNodes           :: !(Set NodeID)
+  , _nodeId               :: !NodeID
+  , _publicKeys           :: !(Map NodeID PublicKey)
+  , _clientPublicKeys     :: !(Map NodeID PublicKey)
+  , _myPrivateKey         :: !PrivateKey
+  , _myPublicKey          :: !PublicKey
+  , _electionTimeoutRange :: !(Int,Int)
+  , _heartbeatTimeout     :: !Int
+  , _batchTimeDelta       :: !NominalDiffTime
+  , _enableDebug          :: !Bool
+  , _clientTimeoutLimit   :: !Int
+  }
+  deriving (Show, Generic)
+makeLenses ''Config
+instance ToJSON NominalDiffTime where
+  toJSON = toJSON . show . toSeconds'
+instance FromJSON NominalDiffTime where
+  parseJSON (String s) = case readMaybe $ Text.unpack s of
+    Just s' -> return $ fromSeconds' s'
+    Nothing -> mzero
+  parseJSON _ = mzero
+instance ToJSON Config where
+  toJSON = genericToJSON defaultOptions { fieldLabelModifier = drop 1 }
+instance FromJSON Config where
+  parseJSON = genericParseJSON defaultOptions { fieldLabelModifier = drop 1 }
+
+data KeySet = KeySet
+  { _ksCluster :: !(Map NodeID PublicKey)
+  , _ksClient  :: !(Map NodeID PublicKey)
+  } deriving (Show)
+
+-- | Type that is serialized and sent over the wire
+data SignedRPC = SignedRPC
+  { _sigDigest :: !Digest
+  , _sigBody   :: !ByteString
+  } deriving (Show, Eq, Generic)
+instance Serialize SignedRPC
+
+-- | Based on the MsgType in the SignedRPC's Digest, we know which set of keys are needed to validate the message
+verifySignedRPC :: KeySet -> SignedRPC -> Either String ()
+verifySignedRPC !KeySet{..} s@(SignedRPC !Digest{..} !bdy)
+  | _digType == CMD || _digType == REV || _digType == CMDB =
+      case Map.lookup _digNodeId _ksClient of
+        Nothing -> Left $! "PubKey not found for NodeID: " ++ show _digNodeId
+        Just !key
+          | key /= _digPubkey -> Left $! "Public key in storage doesn't match digest's key for msg: " ++ show s
+          | otherwise -> if not $ valid bdy key _digSig
+                         then Left $! "Unable to verify SignedRPC sig: " ++ show s
+                         else Right ()
+  | otherwise =
+      case Map.lookup _digNodeId _ksCluster of
+        Nothing -> Left $! "PubKey not found for NodeID: " ++ show _digNodeId
+        Just !key
+          | key /= _digPubkey -> Left $! "Public key in storage doesn't match digest's key for msg: " ++ show s
+          | otherwise -> if not $ valid bdy key _digSig
+                         then Left $! "Unable to verify SignedRPC sig: " ++ show s
+                         else Right ()
+{-# INLINE verifySignedRPC #-}
+
+class WireFormat a where
+  toWire   :: NodeID -> PublicKey -> PrivateKey -> a -> SignedRPC
+  fromWire :: Maybe ReceivedAt -> KeySet -> SignedRPC -> Either String a
+
+data CMDWire = CMDWire !(CommandEntry, NodeID, RequestId)
+  deriving (Show, Generic)
+instance Serialize CMDWire
+
+instance WireFormat Command where
+  toWire nid pubKey privKey Command{..} = case _cmdProvenance of
+    NewMsg -> let bdy = S.encode $ CMDWire (_cmdEntry, _cmdClientId, _cmdRequestId)
+                  sig = sign bdy privKey pubKey
+                  dig = Digest nid sig pubKey CMD
+              in SignedRPC dig bdy
+    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
+  fromWire !ts !ks s@(SignedRPC !dig !bdy) =
+    case verifySignedRPC ks s of
+      Left !err -> Left err
+      Right () -> if _digType dig /= CMD
+        then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with CMDWire instance"
+        else case S.decode bdy of
+            Left !err -> Left $! "Failure to decode CMDWire: " ++ err
+            Right (CMDWire !(ce,nid,rid)) -> Right $! Command ce nid rid $ ReceivedMsg dig bdy ts
+  {-# INLINE toWire #-}
+  {-# INLINE fromWire #-}
+
+instance WireFormat CommandBatch where
+  toWire nid pubKey privKey CommandBatch{..} = case _cmdbProvenance of
+    NewMsg -> let bdy = S.encode ((toWire nid pubKey privKey <$> _cmdbBatch) `using` parList rseq)
+                  sig = sign bdy privKey pubKey
+                  dig = Digest nid sig pubKey CMDB
+              in SignedRPC dig bdy
+    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
+  fromWire !ts !ks s@(SignedRPC dig bdy) = case verifySignedRPC ks s of
+    Left !err -> Left err
+    Right () -> if _digType dig /= CMDB
+      then error $! "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with CMDBWire instance"
+      else case S.decode bdy of
+        Left !err -> Left $ "Failure to decode CMDBWire: " ++ err
+        Right !cmdb' -> gatherValidCmdbs (ReceivedMsg dig bdy ts) ((fromWire ts ks <$> cmdb') `using` parList rseq)
+  {-# INLINE toWire #-}
+  {-# INLINE fromWire #-}
+
+gatherValidCmdbs :: Provenance -> [Either String Command] -> Either String CommandBatch
+gatherValidCmdbs prov ec = (`CommandBatch` prov) <$> sequence ec
+{-# INLINE gatherValidCmdbs #-}
+
+data CMDRWire = CMDRWire (CommandResult, NodeID, NodeID, RequestId)
+  deriving (Show, Generic)
+instance Serialize CMDRWire
+
+instance WireFormat CommandResponse where
+  toWire nid pubKey privKey CommandResponse{..} = case _cmdrProvenance of
+    NewMsg -> let bdy = S.encode $ CMDRWire (_cmdrResult,_cmdrLeaderId,_cmdrNodeId,_cmdrRequestId)
+                  sig = sign bdy privKey pubKey
+                  dig = Digest nid sig pubKey CMDR
+              in SignedRPC dig bdy
+    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
+  fromWire ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
+    Left !err -> Left err
+    Right () -> if _digType dig /= CMDR
+      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with CMDRWire instance"
+      else case S.decode bdy of
+        Left !err -> Left $! "Failure to decode CMDRWire: " ++ err
+        Right (CMDRWire !(r,lid,nid,rid)) -> Right $! CommandResponse r lid nid rid $ ReceivedMsg dig bdy ts
+  {-# INLINE toWire #-}
+  {-# INLINE fromWire #-}
+
+data LogEntry = LogEntry
+  { _leTerm    :: !Term
+  , _leCommand :: !Command
+  , _leHash    :: !ByteString
+  }
+  deriving (Show, Eq, Generic)
+makeLenses ''LogEntry
+
+newtype Log a = Log { _lEntries :: Seq a }
+    deriving (Eq,Show,Ord,Generic,Monoid,Functor,Foldable,Traversable,Applicative,Monad,NFData)
+makeLenses ''Log
+instance (t ~ Log a) => Rewrapped (Log a) t
+instance Wrapped (Log a) where
+    type Unwrapped (Log a) = Seq a
+    _Wrapped' = iso _lEntries Log
+instance Cons (Log a) (Log a) a a where
+    _Cons = _Wrapped . _Cons . mapping _Unwrapped
+instance Snoc (Log a) (Log a) a a where
+    _Snoc = _Wrapped . _Snoc . firsting _Unwrapped
+type instance IxValue (Log a) = a
+type instance Lens.Index (Log a) = LogIndex
+instance Ixed (Log a) where ix i = lEntries.ix (fromIntegral i)
+
+data LEWire = LEWire (Term, SignedRPC, ByteString)
+  deriving (Show, Generic)
+instance Serialize LEWire
+
+decodeLEWire' :: Maybe ReceivedAt -> KeySet -> LEWire -> Either String LogEntry
+decodeLEWire' !ts !ks (LEWire !(t,cmd,hsh)) = case fromWire ts ks cmd of
+      Left !err -> Left $!err
+      Right !cmd' -> Right $! LogEntry t cmd' hsh
+{-# INLINE decodeLEWire' #-}
+
+-- TODO: check if `toSeqLogEntry ele = Seq.fromList <$> sequence ele` is fusable?
+toSeqLogEntry :: [Either String LogEntry] -> Either String (Seq LogEntry)
+toSeqLogEntry !ele = go ele mempty
+  where
+    go [] s = Right $! s
+    go (Right le:les) s = go les (s |> le)
+    go (Left err:_) _ = Left $! err
+{-# INLINE toSeqLogEntry #-}
+
+decodeLEWire :: Maybe ReceivedAt -> KeySet -> [LEWire] -> Either String (Seq LogEntry)
+decodeLEWire !ts !ks !les = go les Seq.empty
+  where
+    go [] s = Right $! s
+    go (LEWire !(t,cmd,hsh):ls) v = case fromWire ts ks cmd of
+      Left err -> Left $! err
+      Right cmd' -> go ls (v |> LogEntry t cmd' hsh)
+{-# INLINE decodeLEWire #-}
+
+encodeLEWire :: NodeID -> PublicKey -> PrivateKey -> Seq LogEntry -> [LEWire]
+encodeLEWire nid pubKey privKey les =
+  (\LogEntry{..} -> LEWire (_leTerm, toWire nid pubKey privKey _leCommand, _leHash)) <$> toList les
+{-# INLINE encodeLEWire #-}
+
+data AppendEntries = AppendEntries
+  { _aeTerm        :: !Term
+  , _leaderId      :: !NodeID
+  , _prevLogIndex  :: !LogIndex
+  , _prevLogTerm   :: !Term
+  , _aeEntries     :: !(Seq LogEntry)
+  , _aeQuorumVotes :: !(Set RequestVoteResponse)
+  , _aeProvenance  :: !Provenance
+  }
+  deriving (Show, Eq, Generic)
+
+data AEWire = AEWire (Term,NodeID,LogIndex,Term,[LEWire],[SignedRPC])
+  deriving (Show, Generic)
+instance Serialize AEWire
+
+instance WireFormat AppendEntries where
+  toWire nid pubKey privKey AppendEntries{..} = case _aeProvenance of
+    NewMsg -> let bdy = S.encode $ AEWire (_aeTerm
+                                          ,_leaderId
+                                          ,_prevLogIndex
+                                          ,_prevLogTerm
+                                          ,encodeLEWire nid pubKey privKey _aeEntries
+                                          ,toWire nid pubKey privKey <$> toList _aeQuorumVotes)
+                  sig = sign bdy privKey pubKey
+                  dig = Digest nid sig pubKey AE
+              in SignedRPC dig bdy
+    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
+  fromWire !ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
+    Left !err -> Left err
+    Right () -> if _digType dig /= AE
+      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with AEWire instance"
+      else case S.decode bdy of
+        Left err -> Left $! "Failure to decode AEWire: " ++ err
+        Right (AEWire (t,lid,pli,pt,les,vts)) -> runEval $ do
+          eLes <- rpar (toSeqLogEntry ((decodeLEWire' ts ks <$> les) `using` parList rseq))
+          eRvr <- rseq (toSetRvr ((fromWire ts ks <$> vts) `using` parList rseq))
+          case eRvr of
+            Left !err -> return $! Left $! "Caught an invalid RVR in an AE: " ++ err
+            Right !vts' -> do
+              _ <- rseq eLes
+              case eLes of
+                Left !err -> return $! Left $ "Found a LogEntry with an invalid Command: " ++ err
+                Right !les' -> return $! Right $! AppendEntries t lid pli pt les' vts' $ ReceivedMsg dig bdy ts
+  {-# INLINE toWire #-}
+  {-# INLINE fromWire #-}
+
+data AppendEntriesResponse = AppendEntriesResponse
+  { _aerTerm       :: !Term
+  , _aerNodeId     :: !NodeID
+  , _aerSuccess    :: !Bool
+  , _aerConvinced  :: !Bool
+  , _aerIndex      :: !LogIndex
+  , _aerHash       :: !ByteString
+  , _aerWasVerified:: !Bool
+  , _aerProvenance :: !Provenance
+  }
+  deriving (Show, Generic, Eq)
+
+instance Ord AppendEntriesResponse where
+  -- This is here to get a set of AERs to order correctly
+  -- Node matters most (apples to apples)
+  -- Term supersedes index always
+  -- Index is really what we're after for how Set AER is used
+  -- Hash matters more than verified due to conflict resolution
+  -- Then verified, which is metadata really, because if everything up to that point is the same then the one that already ran through crypto is more valuable
+  -- After that it doesn't matter.
+  (AppendEntriesResponse t n s c i h v p) <= (AppendEntriesResponse t' n' s' c' i' h' v' p') =
+    (n,t,i,h,v,s,c,p) <= (n',t',i',h',v',s',c',p')
+
+data AERWire = AERWire (Term,NodeID,Bool,Bool,LogIndex,ByteString)
+  deriving (Show, Generic)
+instance Serialize AERWire
+
+instance WireFormat AppendEntriesResponse where
+  toWire nid pubKey privKey AppendEntriesResponse{..} = case _aerProvenance of
+    NewMsg -> let bdy = S.encode $ AERWire ( _aerTerm
+                                               , _aerNodeId
+                                               , _aerSuccess
+                                               , _aerConvinced
+                                               , _aerIndex
+                                               , _aerHash)
+                  sig = sign bdy privKey pubKey
+                  dig = Digest nid sig pubKey AER
+              in SignedRPC dig bdy
+    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
+  fromWire !ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
+    Left !err -> Left $! err
+    Right () -> if _digType dig /= AER
+      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with AERWire instance"
+      else case S.decode bdy of
+        Left !err -> Left $! "Failure to decode AERWire: " ++ err
+        Right (AERWire !(t,nid,s',c,i,h)) -> Right $! AppendEntriesResponse t nid s' c i h True $ ReceivedMsg dig bdy ts
+  {-# INLINE toWire #-}
+  {-# INLINE fromWire #-}
+
+
+newtype AlotOfAERs = AlotOfAERs { _unAlot :: Map NodeID (Set AppendEntriesResponse)}
+  deriving (Show, Eq)
+
+instance Monoid AlotOfAERs where
+  mempty = AlotOfAERs Map.empty
+  mappend (AlotOfAERs m) (AlotOfAERs m') = AlotOfAERs $ Map.unionWith Set.union m m'
+
+data RequestVote = RequestVote
+  { _rvTerm        :: !Term
+  , _rvCandidateId :: !NodeID -- Sender ID Right? We don't forward RV's
+  , _lastLogIndex  :: !LogIndex
+  , _lastLogTerm   :: !Term
+  , _rvProvenance  :: !Provenance
+  }
+  deriving (Show, Eq, Generic)
+
+data RVWire = RVWire (Term,NodeID,LogIndex,Term)
+  deriving (Show, Generic)
+instance Serialize RVWire
+
+instance WireFormat RequestVote where
+  toWire nid pubKey privKey RequestVote{..} = case _rvProvenance of
+    NewMsg -> let bdy = S.encode $ RVWire ( _rvTerm
+                                          , _rvCandidateId
+                                          , _lastLogIndex
+                                          , _lastLogTerm)
+                  sig = sign bdy privKey pubKey
+                  dig = Digest nid sig pubKey RV
+              in SignedRPC dig bdy
+    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
+  fromWire !ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
+    Left !err -> Left $! err
+    Right () -> if _digType dig /= RV
+      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with RVWire instance"
+      else case S.decode bdy of
+        Left !err -> Left $! "Failure to decode RVWire: " ++ err
+        Right (RVWire !(t,cid,lli,llt)) -> Right $! RequestVote t cid lli llt $ ReceivedMsg dig bdy ts
+  {-# INLINE toWire #-}
+  {-# INLINE fromWire #-}
+
+data RequestVoteResponse = RequestVoteResponse
+  { _rvrTerm        :: !Term
+  , _rvrCurLogIndex :: !LogIndex
+  , _rvrNodeId      :: !NodeID
+  , _voteGranted    :: !Bool
+  , _rvrCandidateId :: !NodeID
+  , _rvrProvenance  :: !Provenance
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+data RVRWire = RVRWire (Term,LogIndex,NodeID,Bool,NodeID)
+  deriving (Show, Generic)
+instance Serialize RVRWire
+
+instance WireFormat RequestVoteResponse where
+  toWire nid pubKey privKey RequestVoteResponse{..} = case _rvrProvenance of
+    NewMsg -> let bdy = S.encode $ RVRWire (_rvrTerm,_rvrCurLogIndex,_rvrNodeId,_voteGranted,_rvrCandidateId)
+                  sig = sign bdy privKey pubKey
+                  dig = Digest nid sig pubKey RVR
+              in SignedRPC dig bdy
+    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
+  fromWire !ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
+    Left !err -> Left $! err
+    Right () -> if _digType dig /= RVR
+      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with RVRWire instance"
+      else case S.decode bdy of
+        Left !err -> Left $! "Failure to decode RVRWire: " ++ err
+        Right (RVRWire !(t,li,nid,granted,cid)) -> Right $! RequestVoteResponse t li nid granted cid $ ReceivedMsg dig bdy ts
+  {-# INLINE toWire #-}
+  {-# INLINE fromWire #-}
+
+-- TODO: check if `toSetRvr eRvrs = Set.fromList <$> sequence eRvrs` is fusable?
+toSetRvr :: [Either String RequestVoteResponse] -> Either String (Set RequestVoteResponse)
+toSetRvr eRvrs = go eRvrs Set.empty
+  where
+    go [] s = Right $! s
+    go (Right rvr:rvrs) s = go rvrs (Set.insert rvr s)
+    go (Left err:_) _ = Left $! err
+{-# INLINE toSetRvr #-}
+
+-- the expected behavior here is tricky. For a set of votes, we are actually okay if some are invalid so long as there's a quorum
+-- however while we're still in alpha I think these failures represent a bug. Hence, they should be raised asap.
+decodeRVRWire :: Maybe ReceivedAt -> KeySet -> [SignedRPC] -> Either String (Set RequestVoteResponse)
+decodeRVRWire ts ks votes' = go votes' Set.empty
+  where
+    go [] s = Right $! s
+    go (v:vs) s = case fromWire ts ks v of
+      Left err -> Left $! err
+      Right rvr' -> go vs (Set.insert rvr' s)
+{-# INLINE decodeRVRWire #-}
+
+data Revolution = Revolution
+  { _revClientId   :: !NodeID
+  , _revLeaderId   :: !NodeID
+  , _revRequestId  :: !RequestId
+  , _revProvenance :: !Provenance
+  }
+  deriving (Show, Eq, Generic)
+
+data REVWire = REVWire (NodeID,NodeID,RequestId)
+  deriving (Show, Generic)
+instance Serialize REVWire
+
+instance WireFormat Revolution where
+  toWire nid pubKey privKey Revolution{..} = case _revProvenance of
+    NewMsg -> let bdy = S.encode $ REVWire (_revClientId,_revLeaderId,_revRequestId)
+                  sig = sign bdy privKey pubKey
+                  dig = Digest nid sig pubKey REV
+              in SignedRPC dig bdy
+    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
+  fromWire !ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
+    Left !err -> Left $! err
+    Right () -> if _digType dig /= REV
+      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with REVWire instance"
+      else case S.decode bdy of
+        Left !err -> Left $! "Failure to decode REVWire: " ++ err
+        Right (REVWire !(cid,lid,rid)) -> Right $! Revolution cid lid rid $ ReceivedMsg dig bdy ts
+  {-# INLINE toWire #-}
+  {-# INLINE fromWire #-}
+
+
+data RPC = AE'   AppendEntries
+         | AER'  AppendEntriesResponse
+         | RV'   RequestVote
+         | RVR'  RequestVoteResponse
+         | CMD'  Command
+         | CMDB' CommandBatch
+         | CMDR' CommandResponse
+         | REV'  Revolution
+  deriving (Show, Generic)
+
+signedRPCtoRPC :: Maybe ReceivedAt -> KeySet -> SignedRPC -> Either String RPC
+signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ AE)   _) = (\rpc -> rpc `seq` AE'   rpc) <$> fromWire ts ks s
+signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ AER)  _) = (\rpc -> rpc `seq` AER'  rpc) <$> fromWire ts ks s
+signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ RV)   _) = (\rpc -> rpc `seq` RV'   rpc) <$> fromWire ts ks s
+signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ RVR)  _) = (\rpc -> rpc `seq` RVR'  rpc) <$> fromWire ts ks s
+signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ CMD)  _) = (\rpc -> rpc `seq` CMD'  rpc) <$> fromWire ts ks s
+signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ CMDR) _) = (\rpc -> rpc `seq` CMDR' rpc) <$> fromWire ts ks s
+signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ CMDB) _) = (\rpc -> rpc `seq` CMDB' rpc) <$> fromWire ts ks s
+signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ REV)  _) = (\rpc -> rpc `seq` REV'  rpc) <$> fromWire ts ks s
+{-# INLINE signedRPCtoRPC #-}
+
+rpcToSignedRPC :: NodeID -> PublicKey -> PrivateKey -> RPC -> SignedRPC
+rpcToSignedRPC nid pubKey privKey (AE' v) = toWire nid pubKey privKey v
+rpcToSignedRPC nid pubKey privKey (AER' v) = toWire nid pubKey privKey v
+rpcToSignedRPC nid pubKey privKey (RV' v) = toWire nid pubKey privKey v
+rpcToSignedRPC nid pubKey privKey (RVR' v) = toWire nid pubKey privKey v
+rpcToSignedRPC nid pubKey privKey (CMD' v) = toWire nid pubKey privKey v
+rpcToSignedRPC nid pubKey privKey (CMDR' v) = toWire nid pubKey privKey v
+rpcToSignedRPC nid pubKey privKey (CMDB' v) = toWire nid pubKey privKey v
+rpcToSignedRPC nid pubKey privKey (REV' v) = toWire nid pubKey privKey v
+{-# INLINE rpcToSignedRPC #-}
+
+data Event = ERPC RPC
+           | AERs AlotOfAERs
+           | ElectionTimeout String
+           | HeartbeatTimeout String
+  deriving (Show)
+
+data Role = Follower
+          | Candidate
+          | Leader
+  deriving (Show, Generic, Eq)
+
+data Metric
+  -- Consensus metrics:
+  = MetricTerm Term
+  | MetricCommitIndex LogIndex
+  | MetricCommitPeriod Double          -- For computing throughput
+  | MetricCurrentLeader (Maybe NodeID)
+  | MetricHash ByteString
+  -- Node metrics:
+  | MetricNodeId NodeID
+  | MetricRole Role
+  | MetricAppliedIndex LogIndex
+  | MetricApplyLatency Double
+  -- Cluster metrics:
+  | MetricClusterSize Int
+  | MetricQuorumSize Int
+  | MetricAvailableSize Int
+
+-- | A structure containing all the implementation details for running
+-- the raft protocol.
+-- Types:
+-- nt -- "node type", ie identifier (host/port, topic, subject)
+-- et -- "entry type", serialized format for submissions into Raft
+-- rt -- "return type", serialized format for "results" or "responses"
+-- mt -- "message type", serialized format for sending over wire
+data RaftSpec m = RaftSpec
+  {
+    -- ^ Function to get a log entry from persistent storage.
+    _readLogEntry     :: LogIndex -> m (Maybe CommandEntry) -- Simple [unused]
+
+    -- ^ Function to write a log entry to persistent storage.
+  , _writeLogEntry    :: LogIndex -> (Term,CommandEntry) -> m () -- Simple [unused]
+
+    -- ^ Function to get the term number from persistent storage.
+  , _readTermNumber   :: m Term -- Simple [unused]
+
+    -- ^ Function to write the term number to persistent storage.
+  , _writeTermNumber  :: Term -> m () -- Simple,Util(updateTerm[write only])
+
+    -- ^ Function to read the node voted for from persistent storage.
+  , _readVotedFor     :: m (Maybe NodeID) -- Simple [unused]
+
+    -- ^ Function to write the node voted for to persistent storage.
+  , _writeVotedFor    :: Maybe NodeID -> m () -- Simple,Role [write only]
+
+    -- ^ Function to apply a log entry to the state machine.
+  , _applyLogEntry    :: CommandEntry -> m CommandResult -- Simple,Handler
+
+    -- ^ Function to send a message to a node.
+  , _sendMessage      :: NodeID -> ByteString -> m () -- Simple,Sender
+
+    -- ^ Send more than one message at once
+  , _sendMessages     :: [(NodeID,ByteString)] -> m () -- Simple,Sender
+
+    -- ^ Function to get the next message.
+  , _getMessage       :: m (ReceivedAt, SignedRPC) -- Simple,Util(messageReceiver)
+
+    -- ^ Function to get the next N SignedRPCs not of type CMD, CMDB, or AER
+  , _getMessages   :: Int -> m [(ReceivedAt, SignedRPC)] -- Simple,Util(messageReceiver)
+
+    -- ^ Function to get the next N SignedRPCs of type CMD or CMDB
+  , _getNewCommands   :: Int -> m [(ReceivedAt, SignedRPC)] -- Simple,Util(messageReceiver)
+
+    -- ^ Function to get the next N SignedRPCs of type AER
+  , _getNewEvidence   :: Int -> m [(ReceivedAt, SignedRPC)] -- Simple,Util(messageReceiver)
+
+    -- ^ Function to log a debug message (no newline).
+  , _debugPrint       :: NodeID -> String -> m () -- Simple,Util(debug)
+
+  , _publishMetric    :: Metric -> m ()
+
+  , _getTimestamp     :: m UTCTime
+
+  , _random           :: forall a . Random a => (a, a) -> m a -- Simple,Util(randomRIO[timer])
+
+  , _enqueue          :: Event -> m () -- Simple,Util(enqueueEvent)
+
+  , _enqueueMultiple  :: [Event] -> m ()
+
+  , _enqueueLater     :: Int -> Event -> m ThreadId -- Simple,Util(enqueueEventLater[timer])
+
+  , _killEnqueued     :: ThreadId -> m () -- Simple,Timer
+
+  , _dequeue          :: m Event -- Simple,Util(dequeueEvent)
+  }
+makeLenses (''RaftSpec)
+
+data RaftState = RaftState
+  { _role             :: Role -- Handler,Role,Util(debug)
+  , _term             :: Term -- Handler,Role,Sender,Util(updateTerm)
+  , _votedFor         :: Maybe NodeID -- Handler,Role
+  , _lazyVote         :: Maybe (Term, NodeID, LogIndex) -- Handler
+  , _currentLeader    :: Maybe NodeID -- Client,Handler,Role
+  , _ignoreLeader     :: Bool -- Handler
+  , _logEntries       :: Log LogEntry -- Handler,Role,Sender
+  , _commitIndex      :: LogIndex -- Handler
+  , _lastApplied      :: LogIndex -- Handler
+  , _commitProof      :: Map NodeID AppendEntriesResponse -- Handler
+  , _timerThread      :: Maybe ThreadId -- Timer
+  , _timeSinceLastAER :: Int -- microseconds
+  , _replayMap        :: Map (NodeID, Signature) (Maybe CommandResult) -- Handler
+  , _cYesVotes        :: Set RequestVoteResponse -- Handler,Role,Sender
+  , _cPotentialVotes  :: Set NodeID -- Hander,Role,Sender
+  , _lNextIndex       :: Map NodeID LogIndex -- Handler,Role,Sender
+  , _lMatchIndex      :: Map NodeID LogIndex -- Role (never read?)
+  , _lConvinced       :: Set NodeID -- Handler,Role,Sender
+  , _lLastBatchUpdate :: (UTCTime, Maybe ByteString)
+  -- used for metrics
+  , _lastCommitTime   :: Maybe UTCTime
+
+  -- used by clients
+  , _pendingRequests  :: Map RequestId Command -- Client
+  , _currentRequestId :: RequestId -- Client
+  , _numTimeouts      :: Int -- Client
+  }
+makeLenses ''RaftState
+
+initialRaftState :: RaftState
+initialRaftState = RaftState
+  Follower   -- role
+  startTerm  -- term
+  Nothing    -- votedFor
+  Nothing    -- lazyVote
+  Nothing    -- currentLeader
+  False      -- ignoreLeader
+  mempty     -- log
+  startIndex -- commitIndex
+  startIndex -- lastApplied
+  Map.empty  -- commitProof
+  Nothing    -- timerThread
+  0          -- timeSinceLastAER
+  Map.empty  -- replayMap
+  Set.empty  -- cYesVotes
+  Set.empty  -- cPotentialVotes
+  Map.empty  -- lNextIndex
+  Map.empty  -- lMatchIndex
+  Set.empty  -- lConvinced
+  (minBound, Nothing)   -- lLastBatchUpdate (when we start up, we want batching to fire immediately)
+  Nothing    -- lastCommitTime
+  Map.empty  -- pendingRequests
+  0          -- nextRequestId
+  0          -- numTimeouts
+
+
+type Raft m = RWST (RaftEnv m) () RaftState m
+
+data RaftEnv m = RaftEnv
+  { _cfg         :: Config
+  , _clusterSize :: Int
+  , _quorumSize  :: Int  -- Handler,Role
+  , _rs          :: RaftSpec (Raft m)
+  }
+makeLenses ''RaftEnv

--- a/src/Juno/Runtime/Role.hs
+++ b/src/Juno/Runtime/Role.hs
@@ -4,7 +4,6 @@ module Juno.Runtime.Role
   ) where
 
 import Juno.Runtime.Timer
-import Juno.Runtime.Types
 import Juno.Runtime.Protocol.Types
 import Juno.Util.Util
 

--- a/src/Juno/Runtime/Role.hs
+++ b/src/Juno/Runtime/Role.hs
@@ -5,6 +5,7 @@ module Juno.Runtime.Role
 
 import Juno.Runtime.Timer
 import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 import Juno.Util.Util
 
 -- THREAD: unknown/unused. updates state

--- a/src/Juno/Runtime/Sender.hs
+++ b/src/Juno/Runtime/Sender.hs
@@ -27,6 +27,7 @@ import Data.Serialize
 
 import Juno.Util.Util
 import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 import Juno.Runtime.Timer (resetLastBatchUpdate)
 import Juno.Runtime.Log
 

--- a/src/Juno/Runtime/Timer.hs
+++ b/src/Juno/Runtime/Timer.hs
@@ -9,7 +9,7 @@ module Juno.Runtime.Timer
 
 import Control.Monad
 import Control.Lens hiding (Index)
-import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 import Juno.Runtime.Log
 import Juno.Util.Util
 

--- a/src/Juno/Runtime/Types.hs
+++ b/src/Juno/Runtime/Types.hs
@@ -12,80 +12,40 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Juno.Runtime.Types
+--
+-- Share types used in Api/Types.hs and Protocol/Types.
+-- Api is responisble for accepting outside commands
+-- Protocol is part of BFT raft implementation.
+
 module Juno.Runtime.Types
-  ( Raft
-  , RaftSpec(..)
-  , readLogEntry, writeLogEntry, readTermNumber, writeTermNumber
-  , readVotedFor, writeVotedFor, applyLogEntry, sendMessage
-  , sendMessages, getMessage, getMessages, getNewCommands, getNewEvidence
-  , debugPrint, publishMetric, getTimestamp, random
-  , enqueue, enqueueMultiple, dequeue, enqueueLater, killEnqueued
-  , NodeID(..)
+  ( NodeID(..)
   , CommandEntry(..)
   , CommandResult(..)
   , CommandStatus(..)
-  , Term(..), startTerm
-  , LogIndex(..), startIndex
   , RequestId(..), startRequestId, toRequestId
-  , Config(..), otherNodes, nodeId, electionTimeoutRange, heartbeatTimeout
-  , enableDebug, publicKeys, clientPublicKeys, myPrivateKey, clientTimeoutLimit
-  , myPublicKey, batchTimeDelta
-  , Role(..)
-  , Metric(..)
-  , RaftEnv(..), cfg, clusterSize, quorumSize, rs
-  , LogEntry(..), leTerm, leCommand, leHash
-  , Log(..), lEntries
-  , RaftState(..), role, term, votedFor, lazyVote, currentLeader, ignoreLeader
-  , logEntries, commitIndex, commitProof, lastApplied, timerThread, replayMap
-  , cYesVotes, cPotentialVotes, lNextIndex, lMatchIndex, lConvinced
-  , lastCommitTime, numTimeouts, pendingRequests, currentRequestId
-  , timeSinceLastAER, lLastBatchUpdate
-  , initialRaftState
-  -- * RPC
-  , AppendEntries(..)
-  , AppendEntriesResponse(..), AERWire(..), AlotOfAERs(..)
-  , RequestVote(..)
-  , RequestVoteResponse(..)
   , Command(..)
   , CommandResponse(..)
   , CommandBatch(..)
-  , Revolution(..)
-  , RPC(..)
-  , Event(..)
-  , MsgType(..), KeySet(..), Digest(..), Provenance(..), WireFormat(..)
-  , signedRPCtoRPC, rpcToSignedRPC
-  , SignedRPC(..)
+  , MsgType(..), Digest(..), Provenance(..)
   , ReceivedAt(..)
   -- for simplicity, re-export some core types that we need all over the place
   , PublicKey, PrivateKey, Signature(..), sign, valid, importPublic, importPrivate
-  -- for testing & benchmarks
-  , LEWire(..), encodeLEWire, decodeLEWire, decodeRVRWire
-  , verifySignedRPC, CMDWire(..)
   ) where
 
 import Control.Monad (mzero)
-import Control.Parallel.Strategies
-import Control.Concurrent (ThreadId)
-import Control.Lens hiding (Index)
-import qualified Control.Lens as Lens
-import Control.Monad.RWS (RWST)
 import Crypto.Ed25519.Pure ( PublicKey, PrivateKey, Signature(..), sign, valid
                            , importPublic, importPrivate, exportPublic, exportPrivate)
-import Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Set (Set)
-import qualified Data.Set as Set
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Base16 as B16
 import Data.Serialize (Serialize)
 import qualified Data.Serialize as S
 import Data.Word (Word64)
-import Data.Foldable
-import Text.Read (readMaybe)
-import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Thyme.Clock
 import Data.Thyme.Time.Core ()
@@ -96,8 +56,6 @@ import Data.Aeson.Types (defaultOptions,Options(..))
 
 import GHC.Int (Int64)
 import GHC.Generics hiding (from)
-
-import System.Random (Random)
 
 newtype CommandEntry = CommandEntry { unCommandEntry :: ByteString }
   deriving (Show, Eq, Ord, Generic, Serialize)
@@ -113,18 +71,6 @@ instance ToJSON NodeID where
 instance FromJSON NodeID where
   parseJSON = genericParseJSON defaultOptions { fieldLabelModifier = drop 1 }
 
-newtype Term = Term Int
-  deriving (Show, Read, Eq, Enum, Num, Ord, Generic, Serialize)
-
-startTerm :: Term
-startTerm = Term (-1)
-
-newtype LogIndex = LogIndex Int
-  deriving (Show, Read, Eq, Ord, Enum, Num, Real, Integral, Generic, Serialize)
-
-startIndex :: LogIndex
-startIndex = LogIndex (-1)
-
 newtype RequestId = RequestId Int64
   deriving (Show, Read, Eq, Ord, Enum, Num, Generic, Serialize)
 
@@ -133,58 +79,6 @@ startRequestId = RequestId 0
 
 toRequestId :: Int64 -> RequestId
 toRequestId a = RequestId a
-
-data Config = Config
-  { _otherNodes           :: !(Set NodeID)
-  , _nodeId               :: !NodeID
-  , _publicKeys           :: !(Map NodeID PublicKey)
-  , _clientPublicKeys     :: !(Map NodeID PublicKey)
-  , _myPrivateKey         :: !PrivateKey
-  , _myPublicKey          :: !PublicKey
-  , _electionTimeoutRange :: !(Int,Int)
-  , _heartbeatTimeout     :: !Int
-  , _batchTimeDelta       :: !NominalDiffTime
-  , _enableDebug          :: !Bool
-  , _clientTimeoutLimit   :: !Int
-  }
-  deriving (Show, Generic)
-makeLenses ''Config
-instance ToJSON NominalDiffTime where
-  toJSON = toJSON . show . toSeconds'
-instance FromJSON NominalDiffTime where
-  parseJSON (String s) = case readMaybe $ Text.unpack s of
-    Just s' -> return $ fromSeconds' s'
-    Nothing -> mzero
-  parseJSON _ = mzero
-instance ToJSON Config where
-  toJSON = genericToJSON defaultOptions { fieldLabelModifier = drop 1 }
-instance FromJSON Config where
-  parseJSON = genericParseJSON defaultOptions { fieldLabelModifier = drop 1 }
-
-data KeySet = KeySet
-  { _ksCluster :: !(Map NodeID PublicKey)
-  , _ksClient  :: !(Map NodeID PublicKey)
-  } deriving (Show)
-
--- | One way or another we need a way to figure our what set of public keys to use for verification of signatures.
--- By placing the message type in the digest, we can make the WireFormat implementation easier as well. CMD and REV
--- need to use the Client Public Key maps.
-data MsgType = AE | AER | RV | RVR | CMD | CMDR | CMDB | REV
-  deriving (Show, Eq, Ord, Generic)
-instance Serialize MsgType
-
--- | Digest containing Sender ID, Signature, Sender's Public Key and the message type
-data Digest = Digest
-  { _digNodeId :: !NodeID
-  , _digSig    :: !Signature
-  , _digPubkey :: !PublicKey
-  , _digType   :: !MsgType
-  } deriving (Show, Eq, Ord, Generic)
-deriving instance Eq Signature
-deriving instance Ord Signature
-instance Serialize Signature where
-  put (Sig s) = S.put s
-  get = Sig <$> (S.get >>= S.getByteString)
 
 instance Eq PublicKey where
   b == b' = exportPublic b == exportPublic b'
@@ -231,6 +125,21 @@ instance ToJSON (Map NodeID PrivateKey) where
 instance FromJSON (Map NodeID PrivateKey) where
   parseJSON = fmap Map.fromList . parseJSON
 
+-- | Digest containing Sender ID, Signature, Sender's Public Key and the message type
+data Digest = Digest
+  { _digNodeId :: !NodeID
+  , _digSig    :: !Signature
+  , _digPubkey :: !PublicKey
+  , _digType   :: !MsgType
+  } deriving (Show, Eq, Ord, Generic)
+deriving instance Eq Signature
+deriving instance Ord Signature
+instance Serialize Signature where
+  put (Sig s) = S.put s
+  get = Sig <$> (S.get >>= S.getByteString)
+
+instance Serialize Digest
+
 -- These instances suck, but I can't figure out how to use the Get monad to fail out if not
 -- length = 32. For the record, if the getByteString 32 works the imports will not fail
 instance Serialize PublicKey where
@@ -239,14 +148,6 @@ instance Serialize PublicKey where
 instance Serialize PrivateKey where
   put s = S.putByteString (exportPrivate s)
   get = maybe (error "Invalid PubKey") id . importPrivate <$> S.getByteString (32::Int)
-instance Serialize Digest
-
--- | Type that is serialized and sent over the wire
-data SignedRPC = SignedRPC
-  { _sigDigest :: !Digest
-  , _sigBody   :: !ByteString
-  } deriving (Show, Eq, Generic)
-instance Serialize SignedRPC
 
 -- | UTCTime from Thyme of when ZMQ received the message
 newtype ReceivedAt = ReceivedAt {_unReceivedAt :: UTCTime}
@@ -255,6 +156,13 @@ instance Serialize ReceivedAt
 instance Serialize UTCTime
 instance Serialize NominalDiffTime
 instance Serialize Micro
+
+-- | One way or another we need a way to figure our what set of public keys to use for verification of signatures.
+-- By placing the message type in the digest, we can make the WireFormat implementation easier as well. CMD and REV
+-- need to use the Client Public Key maps.
+data MsgType = AE | AER | RV | RVR | CMD | CMDR | CMDB | REV
+  deriving (Show, Eq, Ord, Generic)
+instance Serialize MsgType
 
 -- | Provenance is used to track if we made the message or received it. This is important for re-transmission.
 data Provenance =
@@ -268,31 +176,6 @@ data Provenance =
 -- We really want to be sure that Provenance from one Node isn't by accident transferred to another node.
 -- Without a Serialize instance, we can be REALLY sure.
 
--- | Based on the MsgType in the SignedRPC's Digest, we know which set of keys are needed to validate the message
-verifySignedRPC :: KeySet -> SignedRPC -> Either String ()
-verifySignedRPC !KeySet{..} s@(SignedRPC !Digest{..} !bdy)
-  | _digType == CMD || _digType == REV || _digType == CMDB =
-      case Map.lookup _digNodeId _ksClient of
-        Nothing -> Left $! "PubKey not found for NodeID: " ++ show _digNodeId
-        Just !key
-          | key /= _digPubkey -> Left $! "Public key in storage doesn't match digest's key for msg: " ++ show s
-          | otherwise -> if not $ valid bdy key _digSig
-                         then Left $! "Unable to verify SignedRPC sig: " ++ show s
-                         else Right ()
-  | otherwise =
-      case Map.lookup _digNodeId _ksCluster of
-        Nothing -> Left $! "PubKey not found for NodeID: " ++ show _digNodeId
-        Just !key
-          | key /= _digPubkey -> Left $! "Public key in storage doesn't match digest's key for msg: " ++ show s
-          | otherwise -> if not $ valid bdy key _digSig
-                         then Left $! "Unable to verify SignedRPC sig: " ++ show s
-                         else Right ()
-{-# INLINE verifySignedRPC #-}
-
-class WireFormat a where
-  toWire   :: NodeID -> PublicKey -> PrivateKey -> a -> SignedRPC
-  fromWire :: Maybe ReceivedAt -> KeySet -> SignedRPC -> Either String a
-
 data Command = Command
   { _cmdEntry      :: !CommandEntry
   , _cmdClientId   :: !NodeID
@@ -301,57 +184,10 @@ data Command = Command
   }
   deriving (Show, Eq, Generic)
 
-data CMDWire = CMDWire !(CommandEntry, NodeID, RequestId)
-  deriving (Show, Generic)
-instance Serialize CMDWire
-
-instance WireFormat Command where
-  toWire nid pubKey privKey Command{..} = case _cmdProvenance of
-    NewMsg -> let bdy = S.encode $ CMDWire (_cmdEntry, _cmdClientId, _cmdRequestId)
-                  sig = sign bdy privKey pubKey
-                  dig = Digest nid sig pubKey CMD
-              in SignedRPC dig bdy
-    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
-  fromWire !ts !ks s@(SignedRPC !dig !bdy) =
-    case verifySignedRPC ks s of
-      Left !err -> Left err
-      Right () -> if _digType dig /= CMD
-        then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with CMDWire instance"
-        else case S.decode bdy of
-            Left !err -> Left $! "Failure to decode CMDWire: " ++ err
-            Right (CMDWire !(ce,nid,rid)) -> Right $! Command ce nid rid $ ReceivedMsg dig bdy ts
-  {-# INLINE toWire #-}
-  {-# INLINE fromWire #-}
-
 data CommandBatch = CommandBatch
   { _cmdbBatch :: ![Command]
   , _cmdbProvenance :: !Provenance
   } deriving (Show, Eq, Generic)
-
-data CMDBWire = CMDBWire ![SignedRPC]
-  deriving (Show, Generic)
-instance Serialize CMDBWire
-
-instance WireFormat CommandBatch where
-  toWire nid pubKey privKey CommandBatch{..} = case _cmdbProvenance of
-    NewMsg -> let bdy = S.encode ((toWire nid pubKey privKey <$> _cmdbBatch) `using` parList rseq)
-                  sig = sign bdy privKey pubKey
-                  dig = Digest nid sig pubKey CMDB
-              in SignedRPC dig bdy
-    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
-  fromWire !ts !ks s@(SignedRPC dig bdy) = case verifySignedRPC ks s of
-    Left !err -> Left err
-    Right () -> if _digType dig /= CMDB
-      then error $! "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with CMDBWire instance"
-      else case S.decode bdy of
-        Left !err -> Left $ "Failure to decode CMDBWire: " ++ err
-        Right !cmdb' -> gatherValidCmdbs (ReceivedMsg dig bdy ts) ((fromWire ts ks <$> cmdb') `using` parList rseq)
-  {-# INLINE toWire #-}
-  {-# INLINE fromWire #-}
-
-gatherValidCmdbs :: Provenance -> [Either String Command] -> Either String CommandBatch
-gatherValidCmdbs prov ec = (`CommandBatch` prov) <$> sequence ec
-{-# INLINE gatherValidCmdbs #-}
 
 data CommandResponse = CommandResponse
   { _cmdrResult     :: !CommandResult
@@ -362,497 +198,7 @@ data CommandResponse = CommandResponse
   }
   deriving (Show, Eq, Generic)
 
-data CMDRWire = CMDRWire (CommandResult, NodeID, NodeID, RequestId)
-  deriving (Show, Generic)
-instance Serialize CMDRWire
-
-instance WireFormat CommandResponse where
-  toWire nid pubKey privKey CommandResponse{..} = case _cmdrProvenance of
-    NewMsg -> let bdy = S.encode $ CMDRWire (_cmdrResult,_cmdrLeaderId,_cmdrNodeId,_cmdrRequestId)
-                  sig = sign bdy privKey pubKey
-                  dig = Digest nid sig pubKey CMDR
-              in SignedRPC dig bdy
-    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
-  fromWire ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
-    Left !err -> Left err
-    Right () -> if _digType dig /= CMDR
-      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with CMDRWire instance"
-      else case S.decode bdy of
-        Left !err -> Left $! "Failure to decode CMDRWire: " ++ err
-        Right (CMDRWire !(r,lid,nid,rid)) -> Right $! CommandResponse r lid nid rid $ ReceivedMsg dig bdy ts
-  {-# INLINE toWire #-}
-  {-# INLINE fromWire #-}
-
-data LogEntry = LogEntry
-  { _leTerm    :: !Term
-  , _leCommand :: !Command
-  , _leHash    :: !ByteString
-  }
-  deriving (Show, Eq, Generic)
-makeLenses ''LogEntry
-
-newtype Log a = Log { _lEntries :: Seq a }
-    deriving (Eq,Show,Ord,Generic,Monoid,Functor,Foldable,Traversable,Applicative,Monad,NFData)
-makeLenses ''Log
-instance (t ~ Log a) => Rewrapped (Log a) t
-instance Wrapped (Log a) where
-    type Unwrapped (Log a) = Seq a
-    _Wrapped' = iso _lEntries Log
-instance Cons (Log a) (Log a) a a where
-    _Cons = _Wrapped . _Cons . mapping _Unwrapped
-instance Snoc (Log a) (Log a) a a where
-    _Snoc = _Wrapped . _Snoc . firsting _Unwrapped
-type instance IxValue (Log a) = a
-type instance Lens.Index (Log a) = LogIndex
-instance Ixed (Log a) where ix i = lEntries.ix (fromIntegral i)
-
-
-data LEWire = LEWire (Term, SignedRPC, ByteString)
-  deriving (Show, Generic)
-instance Serialize LEWire
-
-decodeLEWire' :: Maybe ReceivedAt -> KeySet -> LEWire -> Either String LogEntry
-decodeLEWire' !ts !ks (LEWire !(t,cmd,hsh)) = case fromWire ts ks cmd of
-      Left !err -> Left $!err
-      Right !cmd' -> Right $! LogEntry t cmd' hsh
-{-# INLINE decodeLEWire' #-}
-
--- TODO: check if `toSeqLogEntry ele = Seq.fromList <$> sequence ele` is fusable?
-toSeqLogEntry :: [Either String LogEntry] -> Either String (Seq LogEntry)
-toSeqLogEntry !ele = go ele mempty
-  where
-    go [] s = Right $! s
-    go (Right le:les) s = go les (s |> le)
-    go (Left err:_) _ = Left $! err
-{-# INLINE toSeqLogEntry #-}
-
-decodeLEWire :: Maybe ReceivedAt -> KeySet -> [LEWire] -> Either String (Seq LogEntry)
-decodeLEWire !ts !ks !les = go les Seq.empty
-  where
-    go [] s = Right $! s
-    go (LEWire !(t,cmd,hsh):ls) v = case fromWire ts ks cmd of
-      Left err -> Left $! err
-      Right cmd' -> go ls (v |> LogEntry t cmd' hsh)
-{-# INLINE decodeLEWire #-}
-
-encodeLEWire :: NodeID -> PublicKey -> PrivateKey -> Seq LogEntry -> [LEWire]
-encodeLEWire nid pubKey privKey les =
-  (\LogEntry{..} -> LEWire (_leTerm, toWire nid pubKey privKey _leCommand, _leHash)) <$> toList les
-{-# INLINE encodeLEWire #-}
-
-data AppendEntries = AppendEntries
-  { _aeTerm        :: !Term
-  , _leaderId      :: !NodeID
-  , _prevLogIndex  :: !LogIndex
-  , _prevLogTerm   :: !Term
-  , _aeEntries     :: !(Seq LogEntry)
-  , _aeQuorumVotes :: !(Set RequestVoteResponse)
-  , _aeProvenance  :: !Provenance
-  }
-  deriving (Show, Eq, Generic)
-
-data AEWire = AEWire (Term,NodeID,LogIndex,Term,[LEWire],[SignedRPC])
-  deriving (Show, Generic)
-instance Serialize AEWire
-
-instance WireFormat AppendEntries where
-  toWire nid pubKey privKey AppendEntries{..} = case _aeProvenance of
-    NewMsg -> let bdy = S.encode $ AEWire (_aeTerm
-                                          ,_leaderId
-                                          ,_prevLogIndex
-                                          ,_prevLogTerm
-                                          ,encodeLEWire nid pubKey privKey _aeEntries
-                                          ,toWire nid pubKey privKey <$> toList _aeQuorumVotes)
-                  sig = sign bdy privKey pubKey
-                  dig = Digest nid sig pubKey AE
-              in SignedRPC dig bdy
-    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
-  fromWire !ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
-    Left !err -> Left err
-    Right () -> if _digType dig /= AE
-      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with AEWire instance"
-      else case S.decode bdy of
-        Left err -> Left $! "Failure to decode AEWire: " ++ err
-        Right (AEWire (t,lid,pli,pt,les,vts)) -> runEval $ do
-          eLes <- rpar (toSeqLogEntry ((decodeLEWire' ts ks <$> les) `using` parList rseq))
-          eRvr <- rseq (toSetRvr ((fromWire ts ks <$> vts) `using` parList rseq))
-          case eRvr of
-            Left !err -> return $! Left $! "Caught an invalid RVR in an AE: " ++ err
-            Right !vts' -> do
-              _ <- rseq eLes
-              case eLes of
-                Left !err -> return $! Left $ "Found a LogEntry with an invalid Command: " ++ err
-                Right !les' -> return $! Right $! AppendEntries t lid pli pt les' vts' $ ReceivedMsg dig bdy ts
-  {-# INLINE toWire #-}
-  {-# INLINE fromWire #-}
-
-data AppendEntriesResponse = AppendEntriesResponse
-  { _aerTerm       :: !Term
-  , _aerNodeId     :: !NodeID
-  , _aerSuccess    :: !Bool
-  , _aerConvinced  :: !Bool
-  , _aerIndex      :: !LogIndex
-  , _aerHash       :: !ByteString
-  , _aerWasVerified:: !Bool
-  , _aerProvenance :: !Provenance
-  }
-  deriving (Show, Generic, Eq)
-
-instance Ord AppendEntriesResponse where
-  -- This is here to get a set of AERs to order correctly
-  -- Node matters most (apples to apples)
-  -- Term supersedes index always
-  -- Index is really what we're after for how Set AER is used
-  -- Hash matters more than verified due to conflict resolution
-  -- Then verified, which is metadata really, because if everything up to that point is the same then the one that already ran through crypto is more valuable
-  -- After that it doesn't matter.
-  (AppendEntriesResponse t n s c i h v p) <= (AppendEntriesResponse t' n' s' c' i' h' v' p') =
-    (n,t,i,h,v,s,c,p) <= (n',t',i',h',v',s',c',p')
-
-data AERWire = AERWire (Term,NodeID,Bool,Bool,LogIndex,ByteString)
-  deriving (Show, Generic)
-instance Serialize AERWire
-
-instance WireFormat AppendEntriesResponse where
-  toWire nid pubKey privKey AppendEntriesResponse{..} = case _aerProvenance of
-    NewMsg -> let bdy = S.encode $ AERWire ( _aerTerm
-                                               , _aerNodeId
-                                               , _aerSuccess
-                                               , _aerConvinced
-                                               , _aerIndex
-                                               , _aerHash)
-                  sig = sign bdy privKey pubKey
-                  dig = Digest nid sig pubKey AER
-              in SignedRPC dig bdy
-    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
-  fromWire !ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
-    Left !err -> Left $! err
-    Right () -> if _digType dig /= AER
-      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with AERWire instance"
-      else case S.decode bdy of
-        Left !err -> Left $! "Failure to decode AERWire: " ++ err
-        Right (AERWire !(t,nid,s',c,i,h)) -> Right $! AppendEntriesResponse t nid s' c i h True $ ReceivedMsg dig bdy ts
-  {-# INLINE toWire #-}
-  {-# INLINE fromWire #-}
-
-
-newtype AlotOfAERs = AlotOfAERs { _unAlot :: Map NodeID (Set AppendEntriesResponse)}
-  deriving (Show, Eq)
-
-instance Monoid AlotOfAERs where
-  mempty = AlotOfAERs Map.empty
-  mappend (AlotOfAERs m) (AlotOfAERs m') = AlotOfAERs $ Map.unionWith Set.union m m'
-
-data RequestVote = RequestVote
-  { _rvTerm        :: !Term
-  , _rvCandidateId :: !NodeID -- Sender ID Right? We don't forward RV's
-  , _lastLogIndex  :: !LogIndex
-  , _lastLogTerm   :: !Term
-  , _rvProvenance  :: !Provenance
-  }
-  deriving (Show, Eq, Generic)
-
-data RVWire = RVWire (Term,NodeID,LogIndex,Term)
-  deriving (Show, Generic)
-instance Serialize RVWire
-
-instance WireFormat RequestVote where
-  toWire nid pubKey privKey RequestVote{..} = case _rvProvenance of
-    NewMsg -> let bdy = S.encode $ RVWire ( _rvTerm
-                                          , _rvCandidateId
-                                          , _lastLogIndex
-                                          , _lastLogTerm)
-                  sig = sign bdy privKey pubKey
-                  dig = Digest nid sig pubKey RV
-              in SignedRPC dig bdy
-    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
-  fromWire !ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
-    Left !err -> Left $! err
-    Right () -> if _digType dig /= RV
-      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with RVWire instance"
-      else case S.decode bdy of
-        Left !err -> Left $! "Failure to decode RVWire: " ++ err
-        Right (RVWire !(t,cid,lli,llt)) -> Right $! RequestVote t cid lli llt $ ReceivedMsg dig bdy ts
-  {-# INLINE toWire #-}
-  {-# INLINE fromWire #-}
-
-data RequestVoteResponse = RequestVoteResponse
-  { _rvrTerm        :: !Term
-  , _rvrCurLogIndex :: !LogIndex
-  , _rvrNodeId      :: !NodeID
-  , _voteGranted    :: !Bool
-  , _rvrCandidateId :: !NodeID
-  , _rvrProvenance  :: !Provenance
-  }
-  deriving (Show, Eq, Ord, Generic)
-
-data RVRWire = RVRWire (Term,LogIndex,NodeID,Bool,NodeID)
-  deriving (Show, Generic)
-instance Serialize RVRWire
-
-instance WireFormat RequestVoteResponse where
-  toWire nid pubKey privKey RequestVoteResponse{..} = case _rvrProvenance of
-    NewMsg -> let bdy = S.encode $ RVRWire (_rvrTerm,_rvrCurLogIndex,_rvrNodeId,_voteGranted,_rvrCandidateId)
-                  sig = sign bdy privKey pubKey
-                  dig = Digest nid sig pubKey RVR
-              in SignedRPC dig bdy
-    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
-  fromWire !ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
-    Left !err -> Left $! err
-    Right () -> if _digType dig /= RVR
-      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with RVRWire instance"
-      else case S.decode bdy of
-        Left !err -> Left $! "Failure to decode RVRWire: " ++ err
-        Right (RVRWire !(t,li,nid,granted,cid)) -> Right $! RequestVoteResponse t li nid granted cid $ ReceivedMsg dig bdy ts
-  {-# INLINE toWire #-}
-  {-# INLINE fromWire #-}
-
--- TODO: check if `toSetRvr eRvrs = Set.fromList <$> sequence eRvrs` is fusable?
-toSetRvr :: [Either String RequestVoteResponse] -> Either String (Set RequestVoteResponse)
-toSetRvr eRvrs = go eRvrs Set.empty
-  where
-    go [] s = Right $! s
-    go (Right rvr:rvrs) s = go rvrs (Set.insert rvr s)
-    go (Left err:_) _ = Left $! err
-{-# INLINE toSetRvr #-}
-
--- the expected behavior here is tricky. For a set of votes, we are actually okay if some are invalid so long as there's a quorum
--- however while we're still in alpha I think these failures represent a bug. Hence, they should be raised asap.
-decodeRVRWire :: Maybe ReceivedAt -> KeySet -> [SignedRPC] -> Either String (Set RequestVoteResponse)
-decodeRVRWire ts ks votes' = go votes' Set.empty
-  where
-    go [] s = Right $! s
-    go (v:vs) s = case fromWire ts ks v of
-      Left err -> Left $! err
-      Right rvr' -> go vs (Set.insert rvr' s)
-{-# INLINE decodeRVRWire #-}
-
-data Revolution = Revolution
-  { _revClientId   :: !NodeID
-  , _revLeaderId   :: !NodeID
-  , _revRequestId  :: !RequestId
-  , _revProvenance :: !Provenance
-  }
-  deriving (Show, Eq, Generic)
-
-data REVWire = REVWire (NodeID,NodeID,RequestId)
-  deriving (Show, Generic)
-instance Serialize REVWire
-
-instance WireFormat Revolution where
-  toWire nid pubKey privKey Revolution{..} = case _revProvenance of
-    NewMsg -> let bdy = S.encode $ REVWire (_revClientId,_revLeaderId,_revRequestId)
-                  sig = sign bdy privKey pubKey
-                  dig = Digest nid sig pubKey REV
-              in SignedRPC dig bdy
-    ReceivedMsg{..} -> SignedRPC _pDig _pOrig
-  fromWire !ts !ks s@(SignedRPC !dig !bdy) = case verifySignedRPC ks s of
-    Left !err -> Left $! err
-    Right () -> if _digType dig /= REV
-      then error $ "Invariant Failure: attempting to decode " ++ show (_digType dig) ++ " with REVWire instance"
-      else case S.decode bdy of
-        Left !err -> Left $! "Failure to decode REVWire: " ++ err
-        Right (REVWire !(cid,lid,rid)) -> Right $! Revolution cid lid rid $ ReceivedMsg dig bdy ts
-  {-# INLINE toWire #-}
-  {-# INLINE fromWire #-}
-
-data RPC = AE'   AppendEntries
-         | AER'  AppendEntriesResponse
-         | RV'   RequestVote
-         | RVR'  RequestVoteResponse
-         | CMD'  Command
-         | CMDB' CommandBatch
-         | CMDR' CommandResponse
-         | REV'  Revolution
-  deriving (Show, Generic)
-
-signedRPCtoRPC :: Maybe ReceivedAt -> KeySet -> SignedRPC -> Either String RPC
-signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ AE)   _) = (\rpc -> rpc `seq` AE'   rpc) <$> fromWire ts ks s
-signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ AER)  _) = (\rpc -> rpc `seq` AER'  rpc) <$> fromWire ts ks s
-signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ RV)   _) = (\rpc -> rpc `seq` RV'   rpc) <$> fromWire ts ks s
-signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ RVR)  _) = (\rpc -> rpc `seq` RVR'  rpc) <$> fromWire ts ks s
-signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ CMD)  _) = (\rpc -> rpc `seq` CMD'  rpc) <$> fromWire ts ks s
-signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ CMDR) _) = (\rpc -> rpc `seq` CMDR' rpc) <$> fromWire ts ks s
-signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ CMDB) _) = (\rpc -> rpc `seq` CMDB' rpc) <$> fromWire ts ks s
-signedRPCtoRPC ts ks s@(SignedRPC (Digest _ _ _ REV)  _) = (\rpc -> rpc `seq` REV'  rpc) <$> fromWire ts ks s
-{-# INLINE signedRPCtoRPC #-}
-
-rpcToSignedRPC :: NodeID -> PublicKey -> PrivateKey -> RPC -> SignedRPC
-rpcToSignedRPC nid pubKey privKey (AE' v) = toWire nid pubKey privKey v
-rpcToSignedRPC nid pubKey privKey (AER' v) = toWire nid pubKey privKey v
-rpcToSignedRPC nid pubKey privKey (RV' v) = toWire nid pubKey privKey v
-rpcToSignedRPC nid pubKey privKey (RVR' v) = toWire nid pubKey privKey v
-rpcToSignedRPC nid pubKey privKey (CMD' v) = toWire nid pubKey privKey v
-rpcToSignedRPC nid pubKey privKey (CMDR' v) = toWire nid pubKey privKey v
-rpcToSignedRPC nid pubKey privKey (CMDB' v) = toWire nid pubKey privKey v
-rpcToSignedRPC nid pubKey privKey (REV' v) = toWire nid pubKey privKey v
-{-# INLINE rpcToSignedRPC #-}
-
-data Event = ERPC RPC
-           | AERs AlotOfAERs
-           | ElectionTimeout String
-           | HeartbeatTimeout String
-  deriving (Show)
-
-data Role = Follower
-          | Candidate
-          | Leader
-  deriving (Show, Generic, Eq)
-
 data CommandStatus = CmdSubmitted -- client sets when sending command
                    | CmdAccepted  -- Raft client has recieved command and submitted
                    | CmdApplied { result :: CommandResult }  -- We have a result
                    deriving (Show)
-
-data Metric
-  -- Consensus metrics:
-  = MetricTerm Term
-  | MetricCommitIndex LogIndex
-  | MetricCommitPeriod Double          -- For computing throughput
-  | MetricCurrentLeader (Maybe NodeID)
-  | MetricHash ByteString
-  -- Node metrics:
-  | MetricNodeId NodeID
-  | MetricRole Role
-  | MetricAppliedIndex LogIndex
-  | MetricApplyLatency Double
-  -- Cluster metrics:
-  | MetricClusterSize Int
-  | MetricQuorumSize Int
-  | MetricAvailableSize Int
-
--- | A structure containing all the implementation details for running
--- the raft protocol.
--- Types:
--- nt -- "node type", ie identifier (host/port, topic, subject)
--- et -- "entry type", serialized format for submissions into Raft
--- rt -- "return type", serialized format for "results" or "responses"
--- mt -- "message type", serialized format for sending over wire
-data RaftSpec m = RaftSpec
-  {
-    -- ^ Function to get a log entry from persistent storage.
-    _readLogEntry     :: LogIndex -> m (Maybe CommandEntry) -- Simple [unused]
-
-    -- ^ Function to write a log entry to persistent storage.
-  , _writeLogEntry    :: LogIndex -> (Term,CommandEntry) -> m () -- Simple [unused]
-
-    -- ^ Function to get the term number from persistent storage.
-  , _readTermNumber   :: m Term -- Simple [unused]
-
-    -- ^ Function to write the term number to persistent storage.
-  , _writeTermNumber  :: Term -> m () -- Simple,Util(updateTerm[write only])
-
-    -- ^ Function to read the node voted for from persistent storage.
-  , _readVotedFor     :: m (Maybe NodeID) -- Simple [unused]
-
-    -- ^ Function to write the node voted for to persistent storage.
-  , _writeVotedFor    :: Maybe NodeID -> m () -- Simple,Role [write only]
-
-    -- ^ Function to apply a log entry to the state machine.
-  , _applyLogEntry    :: CommandEntry -> m CommandResult -- Simple,Handler
-
-    -- ^ Function to send a message to a node.
-  , _sendMessage      :: NodeID -> ByteString -> m () -- Simple,Sender
-
-    -- ^ Send more than one message at once
-  , _sendMessages     :: [(NodeID,ByteString)] -> m () -- Simple,Sender
-
-    -- ^ Function to get the next message.
-  , _getMessage       :: m (ReceivedAt, SignedRPC) -- Simple,Util(messageReceiver)
-
-    -- ^ Function to get the next N SignedRPCs not of type CMD, CMDB, or AER
-  , _getMessages   :: Int -> m [(ReceivedAt, SignedRPC)] -- Simple,Util(messageReceiver)
-
-    -- ^ Function to get the next N SignedRPCs of type CMD or CMDB
-  , _getNewCommands   :: Int -> m [(ReceivedAt, SignedRPC)] -- Simple,Util(messageReceiver)
-
-    -- ^ Function to get the next N SignedRPCs of type AER
-  , _getNewEvidence   :: Int -> m [(ReceivedAt, SignedRPC)] -- Simple,Util(messageReceiver)
-
-    -- ^ Function to log a debug message (no newline).
-  , _debugPrint       :: NodeID -> String -> m () -- Simple,Util(debug)
-
-  , _publishMetric    :: Metric -> m ()
-
-  , _getTimestamp     :: m UTCTime
-
-  , _random           :: forall a . Random a => (a, a) -> m a -- Simple,Util(randomRIO[timer])
-
-  , _enqueue          :: Event -> m () -- Simple,Util(enqueueEvent)
-
-  , _enqueueMultiple  :: [Event] -> m ()
-
-  , _enqueueLater     :: Int -> Event -> m ThreadId -- Simple,Util(enqueueEventLater[timer])
-
-  , _killEnqueued     :: ThreadId -> m () -- Simple,Timer
-
-  , _dequeue          :: m Event -- Simple,Util(dequeueEvent)
-  }
-makeLenses (''RaftSpec)
-
-data RaftState = RaftState
-  { _role             :: Role -- Handler,Role,Util(debug)
-  , _term             :: Term -- Handler,Role,Sender,Util(updateTerm)
-  , _votedFor         :: Maybe NodeID -- Handler,Role
-  , _lazyVote         :: Maybe (Term, NodeID, LogIndex) -- Handler
-  , _currentLeader    :: Maybe NodeID -- Client,Handler,Role
-  , _ignoreLeader     :: Bool -- Handler
-  , _logEntries       :: Log LogEntry -- Handler,Role,Sender
-  , _commitIndex      :: LogIndex -- Handler
-  , _lastApplied      :: LogIndex -- Handler
-  , _commitProof      :: Map NodeID AppendEntriesResponse -- Handler
-  , _timerThread      :: Maybe ThreadId -- Timer
-  , _timeSinceLastAER :: Int -- microseconds
-  , _replayMap        :: Map (NodeID, Signature) (Maybe CommandResult) -- Handler
-  , _cYesVotes        :: Set RequestVoteResponse -- Handler,Role,Sender
-  , _cPotentialVotes  :: Set NodeID -- Hander,Role,Sender
-  , _lNextIndex       :: Map NodeID LogIndex -- Handler,Role,Sender
-  , _lMatchIndex      :: Map NodeID LogIndex -- Role (never read?)
-  , _lConvinced       :: Set NodeID -- Handler,Role,Sender
-  , _lLastBatchUpdate :: (UTCTime, Maybe ByteString)
-  -- used for metrics
-  , _lastCommitTime   :: Maybe UTCTime
-
-  -- used by clients
-  , _pendingRequests  :: Map RequestId Command -- Client
-  , _currentRequestId :: RequestId -- Client
-  , _numTimeouts      :: Int -- Client
-  }
-makeLenses ''RaftState
-
-initialRaftState :: RaftState
-initialRaftState = RaftState
-  Follower   -- role
-  startTerm  -- term
-  Nothing    -- votedFor
-  Nothing    -- lazyVote
-  Nothing    -- currentLeader
-  False      -- ignoreLeader
-  mempty     -- log
-  startIndex -- commitIndex
-  startIndex -- lastApplied
-  Map.empty  -- commitProof
-  Nothing    -- timerThread
-  0          -- timeSinceLastAER
-  Map.empty  -- replayMap
-  Set.empty  -- cYesVotes
-  Set.empty  -- cPotentialVotes
-  Map.empty  -- lNextIndex
-  Map.empty  -- lMatchIndex
-  Set.empty  -- lConvinced
-  (minBound, Nothing)   -- lLastBatchUpdate (when we start up, we want batching to fire immediately)
-  Nothing    -- lastCommitTime
-  Map.empty  -- pendingRequests
-  0          -- nextRequestId
-  0          -- numTimeouts
-
-
-type Raft m = RWST (RaftEnv m) () RaftState m
-
-data RaftEnv m = RaftEnv
-  { _cfg         :: Config
-  , _clusterSize :: Int
-  , _quorumSize  :: Int  -- Handler,Role
-  , _rs          :: RaftSpec (Raft m)
-  }
-makeLenses ''RaftEnv

--- a/src/Juno/Spec/Simple.hs
+++ b/src/Juno/Spec/Simple.hs
@@ -14,6 +14,7 @@ import Juno.Consensus.ByzRaft.Server
 import Juno.Consensus.ByzRaft.Client
 import Juno.Runtime.Types
 import Juno.Messaging.Types
+import Juno.Runtime.Protocol.Types
 import Juno.Messaging.ZMQ
 import Juno.Monitoring.Server (startMonitoring)
 

--- a/src/Juno/Util/Util.hs
+++ b/src/Juno/Util/Util.hs
@@ -9,6 +9,7 @@ module Juno.Util.Util
   , runRWS_
   , enqueueEvent, enqueueEventLater
   , dequeueEvent
+  , dequeueCommand
   , logMetric
   , logStaticMetrics
   , setTerm
@@ -75,6 +76,10 @@ enqueueEventLater t event = view (rs.enqueueLater) >>= \f -> f t event
 -- no state update
 dequeueEvent :: Monad m => Raft m Event
 dequeueEvent = join $ view (rs.dequeue)
+
+-- dequeue command from API interface
+dequeueCommand :: MonadIO m => Raft m (RequestId, [CommandEntry])
+dequeueCommand = join $ view (rs.dequeueFromApi)
 
 logMetric :: Monad m => Metric -> Raft m ()
 logMetric metric = view (rs.publishMetric) >>= \f -> f metric

--- a/src/Juno/Util/Util.hs
+++ b/src/Juno/Util/Util.hs
@@ -21,6 +21,7 @@ module Juno.Util.Util
   ) where
 
 import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 import Juno.Util.Combinator
 
 import Control.Lens

--- a/tests/WireFormatSpec.hs
+++ b/tests/WireFormatSpec.hs
@@ -9,6 +9,7 @@ import qualified Data.Set as Set
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Juno.Runtime.Types
+import Juno.Runtime.Protocol.Types
 
 
 spec :: Spec


### PR DESCRIPTION
The API server is now started on each node. For now the PKs of all the consensus nodes are registered as clients as well. The client no longer run in RWS of raft spec, but communicates to the consensus nodes via a shared MVar map and command channel. 
