### PR TITLE
API back REPL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ sumsumarry.json
 .DS_Store
 /monitor/npm-debug.log
 demoui/node_modules
+
+# Test files
+jmeter.log

--- a/executables/JunoRepl.hs
+++ b/executables/JunoRepl.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import qualified Apps.Juno.Repl as App
+
+-- stack exec -- junorepl
+main :: IO ()
+main = App.main

--- a/jmeter/juno_API_jmeter_test.jmx
+++ b/jmeter/juno_API_jmeter_test.jmx
@@ -129,7 +129,7 @@
             <collectionProp name="Arguments.arguments">
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{ &quot;payload&quot;: { &quot;account&quot;: &quot;TSLA&quot;, &quot;amount&quot;: {&quot;numerator&quot;: 100, &quot;denominator&quot;: 1} }, &quot;digest&quot;: { &quot;hash&quot;: &quot;myhash&quot;, &quot;key&quot;: &quot;string&quot; } }</stringProp>
+                <stringProp name="Argument.value">{ &quot;payload&quot;: { &quot;account&quot;: &quot;TSLA&quot;, &quot;amount&quot;: &quot;100%1&quot; }, &quot;digest&quot;: { &quot;hash&quot;: &quot;myhash&quot;, &quot;key&quot;: &quot;string&quot; } }</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
             </collectionProp>
@@ -166,7 +166,7 @@
             <collectionProp name="Arguments.arguments">
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{ &quot;payload&quot;: { &quot;account&quot;: &quot;TSLA&quot;, &quot;amount&quot;: {&quot;numerator&quot;: 50, &quot;denominator&quot;: 1} }, &quot;digest&quot;: { &quot;hash&quot;: &quot;myhash&quot;, &quot;key&quot;: &quot;string&quot; } }</stringProp>
+                <stringProp name="Argument.value">{ &quot;payload&quot;: { &quot;account&quot;: &quot;TSLA&quot;, &quot;amount&quot;: &quot;-50%1&quot;} , &quot;digest&quot;: { &quot;hash&quot;: &quot;myhash&quot;, &quot;key&quot;: &quot;string&quot; } }</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
             </collectionProp>

--- a/jmeter/juno_API_jmeter_test.jmx
+++ b/jmeter/juno_API_jmeter_test.jmx
@@ -129,7 +129,7 @@
             <collectionProp name="Arguments.arguments">
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{ &quot;payload&quot;: { &quot;account&quot;: &quot;TSLA&quot;, &quot;amount&quot;: 100.0 }, &quot;digest&quot;: { &quot;hash&quot;: &quot;myhash&quot;, &quot;key&quot;: &quot;string&quot; } }</stringProp>
+                <stringProp name="Argument.value">{ &quot;payload&quot;: { &quot;account&quot;: &quot;TSLA&quot;, &quot;amount&quot;: {&quot;numerator&quot;: 100, &quot;denominator&quot;: 1} }, &quot;digest&quot;: { &quot;hash&quot;: &quot;myhash&quot;, &quot;key&quot;: &quot;string&quot; } }</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
             </collectionProp>
@@ -166,7 +166,7 @@
             <collectionProp name="Arguments.arguments">
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{ &quot;payload&quot;: { &quot;account&quot;: &quot;TSLA&quot;, &quot;amount&quot;: -50.0 }, &quot;digest&quot;: { &quot;hash&quot;: &quot;myhash&quot;, &quot;key&quot;: &quot;string&quot; } }</stringProp>
+                <stringProp name="Argument.value">{ &quot;payload&quot;: { &quot;account&quot;: &quot;TSLA&quot;, &quot;amount&quot;: {&quot;numerator&quot;: 50, &quot;denominator&quot;: 1} }, &quot;digest&quot;: { &quot;hash&quot;: &quot;myhash&quot;, &quot;key&quot;: &quot;string&quot; } }</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
             </collectionProp>

--- a/jmeter/run_batches.jmx
+++ b/jmeter/run_batches.jmx
@@ -34,7 +34,7 @@
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
                 <stringProp name="Argument.value">{&quot;payload&quot;:{&quot;cmds&quot;:&#xd;
 [&quot;{\&quot;account\&quot;:\&quot;WATER\&quot;}&quot;,&#xd;
-&quot;{\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&quot;{\&quot;amount\&quot;:100,\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&#xd;
+&quot;{\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&quot;{\&quot;amount\&quot;:{\&quot;numerator\&quot;: 100, \&quot;denominator\&quot;: 1} ,\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&#xd;
 &quot;{\&quot;amount\&quot;:1000,\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&#xd;
 &quot;{\&quot;amount\&quot;:100,\&quot;account\&quot;:\&quot;KALE\&quot;}&quot;,&#xd;
 &quot;{\&quot;amount\&quot;:200,\&quot;account\&quot;:\&quot;KALE\&quot;}&quot;,&#xd;

--- a/jmeter/run_batches.jmx
+++ b/jmeter/run_batches.jmx
@@ -34,7 +34,7 @@
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
                 <stringProp name="Argument.value">{&quot;payload&quot;:{&quot;cmds&quot;:&#xd;
 [&quot;{\&quot;account\&quot;:\&quot;WATER\&quot;}&quot;,&#xd;
-&quot;{\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&quot;{\&quot;amount\&quot;:{\&quot;numerator\&quot;: 100, \&quot;denominator\&quot;: 1} ,\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&#xd;
+&quot;{\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&quot;{\&quot;amount\&quot;:\&quot;100%1\&quot;,\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&#xd;
 &quot;{\&quot;amount\&quot;:1000,\&quot;account\&quot;:\&quot;TSLA\&quot;}&quot;,&#xd;
 &quot;{\&quot;amount\&quot;:100,\&quot;account\&quot;:\&quot;KALE\&quot;}&quot;,&#xd;
 &quot;{\&quot;amount\&quot;:200,\&quot;account\&quot;:\&quot;KALE\&quot;}&quot;,&#xd;

--- a/juno.cabal
+++ b/juno.cabal
@@ -26,6 +26,7 @@ library
                      , Apps.Juno.ApiHandlers
                      , Apps.Juno.Ledger
                      , Apps.Juno.Parser
+                     , Apps.Juno.Repl
                      , Juno.Consensus.Api
                      , Juno.Consensus.Handle
                      , Juno.Consensus.Server
@@ -132,6 +133,7 @@ library
                      , unordered-containers
                      , vector >= 0.11.0.0
                      , vector-space >= 0.10.2 && < 0.11
+                     , wreq
                      , yaml
                      , zeromq4-haskell >= 0.6.3
                      , zlib
@@ -167,6 +169,15 @@ executable junoserver
 
 executable junoclient
   main-is:             JunoClient.hs
+  build-depends:       base < 5
+                     , juno
+  hs-source-dirs:      executables
+  ghc-options:         -Wall -threaded -rtsopts
+  ghc-prof-options:    -fprof-auto -fprof-auto-calls
+  default-language:    Haskell2010
+
+executable junorepl
+  main-is:             JunoRepl.hs
   build-depends:       base < 5
                      , juno
   hs-source-dirs:      executables

--- a/src/Apps/Juno/ApiHandlers.hs
+++ b/src/Apps/Juno/ApiHandlers.hs
@@ -105,7 +105,7 @@ createAccountReqHandler bs =
 adjustAccoutReqHandler :: BLC.ByteString -> Either BLC.ByteString [CommandEntry]
 adjustAccoutReqHandler bs =
     case JSON.decode bs of
-        Just (AccountAdjustRequest (AccountAdjustPayload acct amt) _) ->
+        Just (AccountAdjustRequest (AccountAdjustPayload acct (JRational amt)) _) ->
             Right [CommandEntry $ adjustAccountBS acct amt]
         Nothing ->
             Left $ JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON."

--- a/src/Apps/Juno/JsonTypes.hs
+++ b/src/Apps/Juno/JsonTypes.hs
@@ -225,7 +225,7 @@ instance FromJSON LedgerQueryRequest where
 --   "hash": "string",
 --   "key": "string"
 -- }
-
+-- {"data":"","code":"transfer(000->100->101->102->103->003, 100%1)"}
 data TransactBody = TransactBody { _txCode :: Text, _txData :: Text } deriving (Show, Eq)
 instance ToJSON TransactBody where
     toJSON (TransactBody code txData) = object ["code" .= code, "data" .= txData]
@@ -302,3 +302,6 @@ commandToJSONBytes cmd =
       (cmd':acct:[])        | cmd' == "CreateAccount" ->
         JSON.encode $  AccountPayload (E.decodeUtf8 acct)
       _ -> JSON.encode $ TransactBody (E.decodeUtf8 cmd) ""
+
+commandTextToJSONText :: T.Text -> T.Text
+commandTextToJSONText cmd = T.pack . BLC.unpack $ commandToJSONBytes $ BSC.pack . T.unpack $ cmd

--- a/src/Apps/Juno/Repl.hs
+++ b/src/Apps/Juno/Repl.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Apps.Juno.Repl
+ ( main
+ ) where
+
+import Control.Concurrent.Lifted (threadDelay)
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import Data.Either ()
+import Data.Aeson as JSON
+import qualified Data.Text as T
+import qualified Network.Wreq as W
+import System.IO
+
+import Juno.Types
+
+import Apps.Juno.Parser
+import qualified Apps.Juno.JsonTypes as JsonT
+
+prompt :: String
+prompt = "\ESC[0;31mhopper>> \ESC[0m"
+
+promptGreen :: String
+promptGreen = "\ESC[0;32mresult>> \ESC[0m"
+
+flushStr :: String -> IO ()
+flushStr str = putStr str >> hFlush stdout
+
+readPrompt :: IO String
+readPrompt = flushStr prompt >> getLine
+
+apiEndpoint :: Int -> String
+apiEndpoint port = "http://localhost:" ++ show port ++ "/"
+
+submitCmdBatch :: BLC.ByteString -> IO (W.Response BLC.ByteString)
+submitCmdBatch cmdBatch = W.post (cmdBathURL 8001) cmdBatch
+ where
+   cmdBathURL p = apiEndpoint p ++ "api/juno/v1/cmd/batch"
+
+-- { "payload": {"cmdids": ["rid_1","rid_2"]},"digest": { "hash": "string", "key": "string" } }
+submitPollRequestId :: BLC.ByteString -> IO (W.Response BLC.ByteString)
+submitPollRequestId pollReq = W.post (pollURL 8001) pollReq
+ where
+   pollURL p = apiEndpoint p ++ "api/juno/v1/poll"
+
+showResult :: Show a => a -> IO ()
+showResult res = putStrLn $ promptGreen ++ show res
+
+-- |
+-- ObserveAccounts
+-- CreateAccount Acct1
+-- AdjustAccount Acct1 1.0
+-- transfer(Acct1->Acct2, 1%1)
+runREPL :: IO ()
+runREPL = do
+  cmd <- readPrompt
+  case cmd of
+    "" -> runREPL
+    _ -> processInput cmd >> runREPL
+  where
+    processInput input = do
+      cmd' <- return $ BSC.pack input
+      if take 11 input == "batch test:"
+      then do
+        showResult $ show [CommandEntry cmd']
+        threadDelay 1000
+      else if take 4 input == "Poll"
+      then do
+        let cmds = (tail . words) input
+        let pollRequestsJson = rids2PollJSON $ fmap T.pack cmds
+        res <- submitPollRequestId pollRequestsJson
+        showResult res
+      else
+        case readHopper cmd' of
+          Left err -> putStrLn input >> putStrLn err >> runREPL
+          Right _ -> do
+             let cmdJsonBytes = T.pack . BLC.unpack $ JsonT.commandToJSONBytes cmd'
+             let jsonBytes = cmdBatch2JSON (JsonT.CommandBatch [cmdJsonBytes])
+             print jsonBytes
+             res <- submitCmdBatch jsonBytes
+             showResult res
+
+    cmdBatch2JSON :: JsonT.CommandBatch -> BLC.ByteString
+    cmdBatch2JSON cmdBatch = JSON.encode $
+                              JsonT.CommandBatchRequest
+                                cmdBatch
+                                (JsonT.Digest "hashy" "mykey")
+
+    rids2PollJSON :: [T.Text] -> BLC.ByteString
+    rids2PollJSON rids = JSON.encode $
+                          JsonT.PollPayloadRequest
+                           (JsonT.PollPayload rids)
+                           (JsonT.Digest "hashy" "mykey")
+
+-- | Runs a 'Raft nt String String mt'.
+-- Simple fixes nt to 'HostPort' and mt to 'String'.
+main :: IO ()
+main = runREPL -- TODO: REPL will be responsible for singing requests.

--- a/src/Apps/Juno/Repl.hs
+++ b/src/Apps/Juno/Repl.hs
@@ -81,7 +81,6 @@ runREPL = do
           Right _ -> do
              let cmdJsonBytes = T.pack . BLC.unpack $ JsonT.commandToJSONBytes cmd'
              let jsonBytes = cmdBatch2JSON (JsonT.CommandBatch [cmdJsonBytes])
-             print jsonBytes
              res <- submitCmdBatch jsonBytes
              showResult res
     batchToken :: String

--- a/src/Apps/Juno/Repl.hs
+++ b/src/Apps/Juno/Repl.hs
@@ -99,7 +99,7 @@ runREPL = do
     commandToJson :: HopperLiteAdminCommand -> String -> BLC.ByteString
     commandToJson (CreateAccount acct) _ = JSON.encode $ JsonT.AccountPayload (T.strip acct)
     commandToJson (AdjustAccount acct amount) _ =
-      JSON.encode $ JsonT.AccountAdjustPayload acct amount
+      JSON.encode $ JsonT.AccountAdjustPayload acct (JsonT.JRational amount)
     commandToJson _ input = JSON.encode $ JsonT.TransactBody (T.pack input) ""
 
     batchToken :: String

--- a/src/Apps/Juno/Repl.hs
+++ b/src/Apps/Juno/Repl.hs
@@ -6,8 +6,9 @@ module Apps.Juno.Repl
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import Data.Char as C
-import Data.Either ()
+import Control.Exception
 import Data.Aeson as JSON
+import Data.Either ()
 import qualified Data.Text as T
 import qualified Network.Wreq as W
 import System.IO
@@ -54,7 +55,12 @@ runREPL = do
   cmd <- readPrompt
   case cmd of
     "" -> runREPL
-    _ -> processInput cmd >> runREPL
+    _ -> catch
+         (processInput cmd)
+         (\e -> do
+              let err = show (e :: SomeException)
+              putStrLn $ "Invalid Command: " ++ err
+         ) >> runREPL
   where
     processInput input = do
       cmd' <- return $ BSC.pack input

--- a/tests/JsonTypesSpec.hs
+++ b/tests/JsonTypesSpec.hs
@@ -42,7 +42,7 @@ testJsonAdjustAccount = do
      `shouldBe`
        Just AccountAdjustRequest {
                _adjustAccountPayload = AccountAdjustPayload
-               { _adjustAccount = "TSLA", _adjustAmount = 100%1}
+               { _adjustAccount = "TSLA", _adjustAmount = JRational (100 % 1) }
              , _adjustAccountDigest = Digest {_hash = "hashy", _key = "mykey"}
              }
 
@@ -106,17 +106,21 @@ createAccountByteString = BL.pack "{\"digest\":{\"hash\":\"hashy\",\"key\":\"myk
 -- | Adjust account helpers
 
 adjustPayloadDecode :: Bool
-adjustPayloadDecode = (decode $ BL.pack "{\"amount\":100,\"account\":\"TSLA\"}" :: Maybe AccountAdjustPayload) == Just AccountAdjustPayload {_adjustAccount = "TSLA", _adjustAmount = 100.0}
+adjustPayloadDecode = (decode $ BL.pack "{\"amount\":\"100%1\",\"account\":\"TSLA\"}" :: Maybe AccountAdjustPayload) == Just AccountAdjustPayload { _adjustAccount = "TSLA"
+                                                 , _adjustAmount = JRational {jratio = 100 % 1}
+                                                 }
 
 adjustPayloadEncode :: Bool
-adjustPayloadEncode = encode (AccountAdjustPayload "TSLA" 100) == "{\"amount\":100,\"account\":\"TSLA\"}"
+adjustPayloadEncode = encode (AccountAdjustPayload "TSLA" (JRational (100 % 1))) == "{\"amount\":100,\"account\":\"TSLA\"}"
 
 adjustRequestPayloadBS :: BL.ByteString
-adjustRequestPayloadBS =  BL.pack "{\"payload\":{\"amount\":{\"denominator\":1,\"numerator\":100},\"account\":\"TSLA\"},\"digest\":{\"hash\":\"hashy\",\"key\":\"mykey\"}}"
+adjustRequestPayloadBS =  BL.pack "{\"payload\":{\"amount\":\"100%1\",\"account\":\"TSLA\"},\"digest\":{\"hash\":\"hashy\",\"key\":\"mykey\"}}"
 
 encodeAdjustRequest :: BL.ByteString
 encodeAdjustRequest = encode $
-                       AccountAdjustRequest (AccountAdjustPayload (T.pack "TSLA") 100)
+                       AccountAdjustRequest (AccountAdjustPayload (T.pack "TSLA")
+                                                                  (JRational (100%1))
+                                            )
                                            (Digest (T.pack "hashy") (T.pack "mykey"))
 
 decodeAdjustRequest :: Maybe AccountAdjustRequest


### PR DESCRIPTION
Adding a REPL that is back by the Juno API (http calls) and outputs the JSON response. To run `stack exec -- junorepl`
Supports the normal commands: 
`$> ObserveAccounts`
`$> CreateAccount Acct1`
`$> AdjustAccount Acct1 100.0`
`$> Poll {requestId}`
`$> transfer(Acct1->Acct2, 1%1)`
and batching, submitting a batch of size X of the supplied command.
`$> batch test: 500 transfer(Acct1->Acct2, 1 % 1)`
