### PR TITLE
API transfer demo

### DIFF
--- a/jmeter/juno_API_jmeter_test.jmx
+++ b/jmeter/juno_API_jmeter_test.jmx
@@ -11,7 +11,7 @@
       <stringProp name="TestPlan.user_define_classpath"></stringProp>
     </TestPlan>
     <hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="CreateUsers" enabled="true">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Create Adjust TX and Poll" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
@@ -178,6 +178,53 @@
           <stringProp name="HTTPSampler.protocol"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
           <stringProp name="HTTPSampler.path">/api/juno/v1/accounts/adjust</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="CMDID -50 TSLA " enabled="true">
+            <stringProp name="RegexExtractor.useHeaders">unescaped</stringProp>
+            <stringProp name="RegexExtractor.refname">cmdid_4</stringProp>
+            <stringProp name="RegexExtractor.regex">.*&quot;cmdid&quot;:&quot;(\d*)&quot;.*</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default">NOT FOUND CMD1</stringProp>
+            <stringProp name="RegexExtractor.match_number"></stringProp>
+          </RegexExtractor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Transfer" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&quot;payload&quot;: &#xd;
+  {&#xd;
+    &quot;transfer&quot;:&#xd;
+   {&quot;acctFrom&quot;:&quot;000&quot; &#xd;
+   ,&quot;acctTo&quot;:&quot;001&quot;&#xd;
+   ,&quot;amount&quot;:1192.00&#xd;
+   ,&quot;currency&quot;:&quot;USD&quot;&#xd;
+   }&#xd;
+   ,&quot;data&quot;:{&quot;mtmessage&quot;:&quot;{1:F01CHASUS33AXXX0000456150}{2:O1032031160113CHASJPJTAXXX89653582351601132031N}{4:\r\n:20:2016012800266559\r\n:23B:CRED\r\n:32A:160129USD24192,00\r\n:33B:USD24192,00\r\n:50K:/6718000111\r\nSTANDARD LIFE INVESTMENTS LIMITED\r\nGEORGE STREET\r\nEDINBURGH SC EH2 2LL\r\nUNITED KINGDOM\r\n:52A:CHASGB2L\r\n:54A:CHASUS33\r\n:57A:CHASJPJT\r\n:59:/6610024417\r\nTAKAO MARANA\r\nMARUNOUCHI,CHIYODAKU\r\nTOKYO JAPAN\r\n:70:/RFB/6064028LBA790001:71A:OUR\r\n-}\r\n&quot;}&#xd;
+ }&#xd;
+}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8000</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/api/juno/v1/transfer</stringProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/jmeter/run_batches.jmx
+++ b/jmeter/run_batches.jmx
@@ -69,6 +69,187 @@
           </RegexExtractor>
           <hashTree/>
         </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="transfer only" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&quot;payload&quot;:{&quot;cmds&quot;:&#xd;
+[&quot;{\&quot;data\&quot;:\&quot;\&quot;,\&quot;code\&quot;:\&quot;transfer(000-&gt;100-&gt;101-&gt;102-&gt;103-&gt;003, 100%1)\&quot;}&quot;]},&quot;digest&quot;:{&quot;hash&quot;:&quot;hashy&quot;,&quot;key&quot;:&quot;mykey&quot;}}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8000</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/api/juno/v1/cmd/batch</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="CMDID -50 TSLA " enabled="true">
+            <stringProp name="RegexExtractor.useHeaders">unescaped</stringProp>
+            <stringProp name="RegexExtractor.refname">cmdid_4</stringProp>
+            <stringProp name="RegexExtractor.regex">.*&quot;cmdid&quot;:&quot;(\d*)&quot;.*</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default">NOT FOUND CMD1</stringProp>
+            <stringProp name="RegexExtractor.match_number"></stringProp>
+          </RegexExtractor>
+          <hashTree/>
+        </hashTree>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>false</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <threadCounts>true</threadCounts>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Transfers" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <longProp name="ThreadGroup.start_time">1459531179000</longProp>
+        <longProp name="ThreadGroup.end_time">1459531179000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Transfer 000 -&gt; 001 " enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&quot;payload&quot;: &#xd;
+  {&#xd;
+    &quot;transfer&quot;:&#xd;
+   {&quot;acctFrom&quot;:&quot;000&quot; &#xd;
+   ,&quot;acctTo&quot;:&quot;001&quot;&#xd;
+   ,&quot;amount&quot;:1192.00&#xd;
+   ,&quot;currency&quot;:&quot;USD&quot;&#xd;
+   }&#xd;
+   ,&quot;data&quot;:{&quot;mtmessage&quot;:&quot;transfer data&quot;}&#xd;
+ }&#xd;
+}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8000</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/api/juno/v1/transfer</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="CMDID -50 TSLA " enabled="true">
+            <stringProp name="RegexExtractor.useHeaders">unescaped</stringProp>
+            <stringProp name="RegexExtractor.refname">cmdid_4</stringProp>
+            <stringProp name="RegexExtractor.regex">.*&quot;cmdid&quot;:&quot;(\d*)&quot;.*</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default">NOT FOUND CMD1</stringProp>
+            <stringProp name="RegexExtractor.match_number"></stringProp>
+          </RegexExtractor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Transfer 000 -&gt; 001 with real data" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&quot;payload&quot;: &#xd;
+  {&#xd;
+    &quot;transfer&quot;:&#xd;
+   {&quot;acctFrom&quot;:&quot;000&quot; &#xd;
+   ,&quot;acctTo&quot;:&quot;001&quot;&#xd;
+   ,&quot;amount&quot;:1192.00&#xd;
+   ,&quot;currency&quot;:&quot;USD&quot;&#xd;
+   }&#xd;
+   ,&quot;data&quot;:{&quot;mtmessage&quot;:  &quot;{1:F01CHASUS33AXXX0000456150}{2:O1032031160113CHASJPJTAXXX89653582351601132031N}{4:\r\n:20:2016012800266559\r\n:23B:CRED\r\n:32A:160129USD24192,00\r\n:33B:USD24192,00\r\n:50K:/6718000111\r\nSTANDARD LIFE INVESTMENTS LIMITED\r\nGEORGE STREET\r\nEDINBURGH SC EH2 2LL\r\nUNITED KINGDOM\r\n:52A:CHASGB2L\r\n:54A:CHASUS33\r\n:57A:CHASJPJT\r\n:59:/6610024417\r\nTAKAO MARANA\r\nMARUNOUCHI,CHIYODAKU\r\nTOKYO JAPAN\r\n:70:/RFB/6064028LBA790001:71A:OUR\r\n-}\r\n&quot;}&#xd;
+ }&#xd;
+}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8000</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/api/juno/v1/transfer</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="CMDID -50 TSLA " enabled="true">
+            <stringProp name="RegexExtractor.useHeaders">unescaped</stringProp>
+            <stringProp name="RegexExtractor.refname">cmdid_4</stringProp>
+            <stringProp name="RegexExtractor.regex">.*&quot;cmdid&quot;:&quot;(\d*)&quot;.*</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default">NOT FOUND CMD1</stringProp>
+            <stringProp name="RegexExtractor.match_number"></stringProp>
+          </RegexExtractor>
+          <hashTree/>
+        </hashTree>
         <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>

--- a/juno.cabal
+++ b/juno.cabal
@@ -23,6 +23,7 @@ library
                      , Apps.Juno.Command
                      , Apps.Juno.Client
                      , Apps.Juno.JsonTypes
+                     , Apps.Juno.ApiDemoHandler
                      , Apps.Juno.ApiHandlers
                      , Apps.Juno.Ledger
                      , Apps.Juno.Parser

--- a/src/Apps/Juno/ApiDemoHandler.hs
+++ b/src/Apps/Juno/ApiDemoHandler.hs
@@ -31,29 +31,31 @@ transferDemoReqHandler bs =
   where
     toTx to' from' amount = "transfer(" ++ to' ++ "->" ++ from' ++ "," ++ show (toRational amount) ++ ")"
 
--- demo API transfer
---{"payload":
---  {"transfer":
---   {"acctFrom":"000"
---   ,"acctTo":"001"
---   ,"amount":1192.00
---   ,"currency":"USD"
---   }
---   ,"data":
---   {"mtmessage":
---    "{1:F01CHASUS33AXXX0000456150}{2:O1032031160113CHASJPJTAXXX89653582351601132031N}{4:\r
---      \n:20:2016012800266559\r\n:23B:CRED\r\n:32A:160129USD24192,00\r\n:33B:USD24192,00\r
---      \n:50K:/6718000111\r\nSTANDARD LIFE INVESTMENTS LIMITED\r\n1 GEORGE STREET, \r
---      \nEDINBURGH SC EH2 2LL\r\nUNITED KINGDOM\r\n:52A:CHASGB2L\r\n:54A:CHASUS33\r\n:57A:CHASJPJT\r
---      \n:59:/6610024417\r\nTAKAO MARANA \r\nMARUNOUCHI,CHIYODAKU,\r\nTOKYO JAPAN \r
---      \n:70:/RFB/6064028LBA790001\r\n:71A:OUR\r\n-}\r\n\r\n"}
---   }
---}
---
-data TransferJson = TransferJson { acctFromTrans :: String
-                                 , acctToTrans :: String
-                                 , amountTrans :: Double
-                                 , currencyTrans :: String
+{-
+ demo API transfer
+{"payload":
+  {"transfer":
+   {"acctFrom":"000"
+   ,"acctTo":"001"
+   ,"amount":1192.00
+   ,"currency":"USD"
+   }
+   ,"data":
+   {"mtmessage":
+    "{1:F01CHASUS33AXXX0000456150}{2:O1032031160113CHASJPJTAXXX89653582351601132031N}{4:\r
+      \n:20:2016012800266559\r\n:23B:CRED\r\n:32A:160129USD24192,00\r\n:33B:USD24192,00\r
+      \n:50K:/6718000111\r\nSTANDARD LIFE INVESTMENTS LIMITED\r\n1 GEORGE STREET, \r
+      \nEDINBURGH SC EH2 2LL\r\nUNITED KINGDOM\r\n:52A:CHASGB2L\r\n:54A:CHASUS33\r\n:57A:CHASJPJT\r
+      \n:59:/6610024417\r\nTAKAO MARANA \r\nMARUNOUCHI,CHIYODAKU,\r\nTOKYO JAPAN \r
+      \n:70:/RFB/6064028LBA790001\r\n:71A:OUR\r\n}\r\n\r\n"}
+   }
+}
+-}
+
+data TransferJson = TransferJson { _tAcctFrom :: String
+                                 , _tAcctTo :: String
+                                 , _tAmount :: Double
+                                 , _Tcurrency :: String
                                  } deriving (Show, Eq)
 
 instance ToJSON TransferJson where
@@ -98,11 +100,16 @@ instance FromJSON TransactDemoRequest where
                                                <*> ((v .: "payload") >>= (.: "data"))
     parseJSON _ = mzero
 
-goodTrans = JSON.encode $ TransferJson "000" "001" 24192.10 "USD"
-goodBody = JSON.encode $ TransferDataJson  "hi"
+_goodTrans :: BLC.ByteString
+_goodTrans = JSON.encode $ TransferJson "000" "001" 24192.10 "USD"
 
-goodRequest = JSON.encode $ TransactDemoRequest
+_goodBody :: BLC.ByteString
+_goodBody = JSON.encode $ TransferDataJson "hi"
+
+_goodRequest :: BLC.ByteString
+_goodRequest = JSON.encode $ TransactDemoRequest
               (TransferJson "000" "001" 1192.00 "USD")
               (TransferDataJson "test blob")
 
-decodeTransDemoReq = JSON.decode $ goodRequest :: Maybe TransactDemoRequest
+_decodeTransDemoReq :: Maybe TransactDemoRequest
+_decodeTransDemoReq = JSON.decode $ _goodRequest :: Maybe TransactDemoRequest

--- a/src/Apps/Juno/ApiDemoHandler.hs
+++ b/src/Apps/Juno/ApiDemoHandler.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Apps.Juno.ApiDemoHandler (transactDemoReqHandler) where
+
+import Control.Monad.Reader
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.Aeson as JSON
+import           GHC.Generics
+import           Data.Aeson as JSON
+-- import           Data.Aeson.Types (Options(..),defaultOptions,parseMaybe)
+
+import Apps.Juno.JsonTypes
+import Juno.Types hiding (CommandBatch)
+
+transactDemoReqHandler :: BLC.ByteString -> Either BLC.ByteString [CommandEntry]
+transactDemoReqHandler bs =
+    case JSON.decode bs of
+      Just (TransactDemoRequest
+            (TransferJson to' from' amount' _) -- ignoring currency for now USD
+            (TransferDataJson _)
+           ) -> do
+          let txCode = toTx to' from' amount'
+          -- TODO: Store the body swift.
+          Right [CommandEntry $ BSC.pack txCode]
+      Nothing ->
+          Left $ JSON.encode $ commandResponseFailure "" "Malformed input, could not decode input JSON."
+  where
+    toTx to' from' amount = "transfer(" ++ to' ++ "->" ++ from' ++ "," ++ show (toRational amount) ++ ")"
+
+-- demo API transact
+--{"payload":
+--  {"transfer":
+--   {"acctFrom":"000"
+--   ,"acctTo":"001"
+--   ,"amount":1192.00
+--   ,"currency":"USD"
+--   }
+--   ,"data":
+--   {"mtmessage":
+--    "{1:F01CHASUS33AXXX0000456150}{2:O1032031160113CHASJPJTAXXX89653582351601132031N}{4:\r
+--      \n:20:2016012800266559\r\n:23B:CRED\r\n:32A:160129USD24192,00\r\n:33B:USD24192,00\r
+--      \n:50K:/6718000111\r\nSTANDARD LIFE INVESTMENTS LIMITED\r\n1 GEORGE STREET, \r
+--      \nEDINBURGH SC EH2 2LL\r\nUNITED KINGDOM\r\n:52A:CHASGB2L\r\n:54A:CHASUS33\r\n:57A:CHASJPJT\r
+--      \n:59:/6610024417\r\nTAKAO MARANA \r\nMARUNOUCHI,CHIYODAKU,\r\nTOKYO JAPAN \r
+--      \n:70:/RFB/6064028LBA790001\r\n:71A:OUR\r\n-}\r\n\r\n"}
+--   }
+--}
+--
+data TransferJson = TransferJson { acctFromTrans :: String
+                                 , acctToTrans :: String
+                                 , amountTrans :: Double
+                                 , currencyTrans :: String
+                                 } deriving (Show, Eq)
+
+instance ToJSON TransferJson where
+  toJSON (TransferJson acctFrom  acctTo amount currency) =
+      object [ "acctFrom" .= acctFrom
+             , "acctTo" .= acctTo
+             , "amount" .= amount
+             , "currency" .= currency
+             ]
+
+instance FromJSON TransferJson where
+  parseJSON (Object v) = TransferJson <$> v .: "acctFrom"
+                                      <*> v .: "acctTo"
+                                      <*> v .: "amount"
+                                      <*> v .: "currency"
+
+  parseJSON _ = mzero
+
+data TransferDataJson = TransferDataJson String deriving (Show, Eq)
+
+instance ToJSON TransferDataJson where
+  toJSON (TransferDataJson databody) =
+      object ["mtmessage" .= databody]
+
+instance FromJSON TransferDataJson where
+  parseJSON (Object v) = TransferDataJson <$> v .: "mtmessage"
+
+  parseJSON _ = mzero
+
+data TransactDemoRequest = TransactDemoRequest TransferJson TransferDataJson
+                           deriving (Show, Eq, Generic)
+
+instance ToJSON TransactDemoRequest where
+    toJSON (TransactDemoRequest transfer' databody) =
+        object [ "payload" .= object [ "transfer" .=  transfer'
+                                       ,"data" .= databody
+                                      ]
+               ]
+
+instance FromJSON TransactDemoRequest where
+    parseJSON (Object v) = TransactDemoRequest <$> ((v .: "payload") >>= (.: "transfer"))
+                                               <*> ((v .: "payload") >>= (.: "data"))
+    parseJSON _ = mzero
+
+goodTrans = JSON.encode $ TransferJson "000" "001" 24192.10 "USD"
+goodBody = JSON.encode $ TransferDataJson  "hi"
+
+goodRequest = JSON.encode $ TransactDemoRequest
+              (TransferJson "000" "001" 1192.00 "USD")
+              (TransferDataJson "test blob")
+
+decodeTransDemoReq = JSON.decode $ goodRequest :: Maybe TransactDemoRequest

--- a/src/Apps/Juno/ApiDemoHandler.hs
+++ b/src/Apps/Juno/ApiDemoHandler.hs
@@ -67,12 +67,11 @@ instance ToJSON TransferJson where
              ]
 
 instance FromJSON TransferJson where
-  parseJSON (Object v) = TransferJson <$> v .: "acctFrom"
-                                      <*> v .: "acctTo"
-                                      <*> v .: "amount"
-                                      <*> v .: "currency"
-
-  parseJSON _ = mzero
+  parseJSON = withObject "Transfer" $ \obj ->
+                TransferJson <$> obj .:"acctFrom"
+                             <*> obj .: "acctTo"
+                             <*> obj .: "amount"
+                             <*> obj .: "currency"
 
 data TransferDataJson = TransferDataJson String deriving (Show, Eq)
 
@@ -96,9 +95,10 @@ instance ToJSON TransactDemoRequest where
                ]
 
 instance FromJSON TransactDemoRequest where
-    parseJSON (Object v) = TransactDemoRequest <$> ((v .: "payload") >>= (.: "transfer"))
-                                               <*> ((v .: "payload") >>= (.: "data"))
-    parseJSON _ = mzero
+
+  parseJSON = withObject "TransactDemoRequest" $ \obj ->
+                TransactDemoRequest <$> ((obj .: "payload") >>= (.: "transfer"))
+                                    <*> ((obj .: "payload") >>= (.: "data"))
 
 _goodTrans :: BLC.ByteString
 _goodTrans = JSON.encode $ TransferJson "000" "001" 24192.10 "USD"

--- a/src/Apps/Juno/ApiHandlers.hs
+++ b/src/Apps/Juno/ApiHandlers.hs
@@ -35,8 +35,7 @@ import Apps.Juno.Parser
 import Juno.Types hiding (CommandBatch)
 import Schwifty.Swift.M105.Types
 import Schwifty.Swift.M105.Parser
-
-import Apps.Juno.ApiDemoHandler (transactDemoReqHandler)
+import Apps.Juno.ApiDemoHandler (transferDemoReqHandler)
 
 data ApiEnv = ApiEnv {
       _aiToCommands :: InChan (RequestId, [CommandEntry]),
@@ -57,7 +56,7 @@ apiRoutes = route [
              ,("api/swift-submit", swiftSubmission)
              ,("api/ledger-query", ledgerQuery)
               -- demo endpoints
-             ,("api/juno/v1/transact/demo", apiWrapper transactDemoReqHandler)
+             ,("api/juno/v1/transfer", apiWrapper transferDemoReqHandler)
              ]
 
 apiWrapper :: (BLC.ByteString -> Either BLC.ByteString [CommandEntry]) -> ReaderT ApiEnv Snap ()
@@ -84,11 +83,6 @@ adjustAccount = apiWrapper adjustAccoutReqHandler
 -- accept hopercommands transfer(000->100->101->102->103->003, 100%1)
 transactAPI :: ReaderT ApiEnv Snap ()
 transactAPI = apiWrapper transactReqHandler
-
--- juno/jmeter/juno_API_jmeter_test.jmx
--- accept hopercommands transfer(000->100->101->102->103->003, 100%1)
-transactDemoAPI :: ReaderT ApiEnv Snap ()
-transactDemoAPI = apiWrapper transactReqHandler
 
 ledgerQueryAPI :: ReaderT ApiEnv Snap ()
 ledgerQueryAPI = apiWrapper ledgerQueryReqHandler

--- a/src/Apps/Juno/ApiHandlers.hs
+++ b/src/Apps/Juno/ApiHandlers.hs
@@ -36,6 +36,8 @@ import Juno.Types hiding (CommandBatch)
 import Schwifty.Swift.M105.Types
 import Schwifty.Swift.M105.Parser
 
+import Apps.Juno.ApiDemoHandler (transactDemoReqHandler)
+
 data ApiEnv = ApiEnv {
       _aiToCommands :: InChan (RequestId, [CommandEntry]),
       _aiCmdStatusMap :: CommandMVarMap
@@ -54,6 +56,8 @@ apiRoutes = route [
              ,("swift", swiftHandler)
              ,("api/swift-submit", swiftSubmission)
              ,("api/ledger-query", ledgerQuery)
+              -- demo endpoints
+             ,("api/juno/v1/transact/demo", apiWrapper transactDemoReqHandler)
              ]
 
 apiWrapper :: (BLC.ByteString -> Either BLC.ByteString [CommandEntry]) -> ReaderT ApiEnv Snap ()
@@ -80,6 +84,11 @@ adjustAccount = apiWrapper adjustAccoutReqHandler
 -- accept hopercommands transfer(000->100->101->102->103->003, 100%1)
 transactAPI :: ReaderT ApiEnv Snap ()
 transactAPI = apiWrapper transactReqHandler
+
+-- juno/jmeter/juno_API_jmeter_test.jmx
+-- accept hopercommands transfer(000->100->101->102->103->003, 100%1)
+transactDemoAPI :: ReaderT ApiEnv Snap ()
+transactDemoAPI = apiWrapper transactReqHandler
 
 ledgerQueryAPI :: ReaderT ApiEnv Snap ()
 ledgerQueryAPI = apiWrapper ledgerQueryReqHandler

--- a/src/Apps/Juno/Client.hs
+++ b/src/Apps/Juno/Client.hs
@@ -110,7 +110,7 @@ main = do
       getEntries :: IO (RequestId, [CommandEntry])
       getEntries = readChan fromCommands
       -- applyFn :: et -> IO rt
-      applyFn :: CommandEntry -> IO CommandResult
+      applyFn :: (CommandEntry, RequestId) -> IO CommandResult
       applyFn _x = return $ CommandResult "Failure"
   void $ CL.fork $ runClient applyFn getEntries cmdStatusMap'
   threadDelay 100000

--- a/src/Apps/Juno/Client.hs
+++ b/src/Apps/Juno/Client.hs
@@ -110,7 +110,7 @@ main = do
       getEntries :: IO (RequestId, [CommandEntry])
       getEntries = readChan fromCommands
       -- applyFn :: et -> IO rt
-      applyFn :: (CommandEntry, RequestId) -> IO CommandResult
+      applyFn :: Command -> IO CommandResult
       applyFn _x = return $ CommandResult "Failure"
   void $ CL.fork $ runClient applyFn getEntries cmdStatusMap'
   threadDelay 100000

--- a/src/Apps/Juno/Command.hs
+++ b/src/Apps/Juno/Command.hs
@@ -19,17 +19,22 @@ import Data.Aeson (encode, object, (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
 
 import Juno.Types (CommandEntry(..), CommandResult(..))
+import Juno.Types.Base (RequestId)
 import Schwifty.Swift.M105.Types (SWIFT)
 
 import Apps.Juno.Parser
 import Apps.Juno.Ledger (runQuery, convertQuery)
 
 -- state of hopper
-newtype JunoEnv = JunoEnv {getStateMVar :: MV.MVar (DEval.PersistentState, Map.Map DEval.TransactionId SWIFT)}
+newtype JunoEnv = JunoEnv {getStateMVar :: MV.MVar (DEval.PersistentState
+                                                  , Map.Map DEval.TransactionId SWIFT
+                                                  , Map.Map RequestId Text -- input to save.
+                                                   )
+                          }
 
 -- hopper
 starterEnv :: IO JunoEnv
-starterEnv = JunoEnv <$> MV.newMVar (DEval.initialState,Map.empty)
+starterEnv = JunoEnv <$> MV.newMVar (DEval.initialState, Map.empty, Map.empty)
 
 balances :: DEval.PersistentState -> Map.Map Text Rational
 balances (DEval.PersistentState _ bals _) = bals
@@ -38,80 +43,85 @@ setBalances :: Map.Map Text Rational -> DEval.PersistentState -> DEval.Persisten
 setBalances bals ps = ps { DEval._persistentBalances = bals }
 
 --JunoEnv:  MVar (State, Map(TX -> Swift))
-runCommand :: JunoEnv -> CommandEntry -> IO CommandResult
-runCommand env cmd' = do
+runCommand :: JunoEnv -> (CommandEntry, RequestId) -> IO CommandResult
+runCommand env (cmd', rid) = do
   mvar <- return $ getStateMVar env
-  (ps, ss) <- MV.takeMVar mvar -- persistent s, swift
+  (ps, ss, store) <- MV.takeMVar mvar -- persistent s, swift, prog input store
   let bals = balances ps
   case readHopper $ unCommandEntry cmd' of
     Left err -> do
-      MV.putMVar mvar (ps,ss)
+      MV.putMVar mvar (ps, ss, store)
       return $ CommandResult $ BSC.pack err
     Right cmd -> fmap CommandResult $ handle
         (\e -> do
-            MV.putMVar mvar (ps,ss)
+            MV.putMVar mvar (ps, ss, store)
             return $ BSC.pack $ show (e :: SomeException)) $
         case cmd of
             CreateAccount acct ->
                 if Map.member acct bals
                 then do
-                    MV.putMVar mvar (ps,ss)
+                    MV.putMVar mvar (ps, ss, store)
                     return "Account Already Exists"
                 else do
-                    MV.putMVar mvar $! (setBalances (Map.insert acct 0 bals) ps, ss)
+                    MV.putMVar mvar $! (setBalances (Map.insert acct 0 bals) ps, ss, store)
                     return $ BSC.pack $ "Created Account: " ++ show acct
 
             AdjustAccount acct amount ->
                 if Map.member acct bals
                 then do
-                    MV.putMVar mvar $! (setBalances (Map.adjust (+ amount) acct bals) ps, ss)
+                    MV.putMVar mvar $! (setBalances (Map.adjust (+ amount) acct bals) ps, ss, store)
                     return $ BSC.pack $ "Adjusted Account " ++ show acct ++ " by " ++ show amount
                 else do
-                    MV.putMVar mvar (ps, ss)
+                    MV.putMVar mvar (ps, ss, store)
                     return $ BSC.pack $ "Error: Account " ++ show acct ++ " does not exist!"
 
             ObserveAccount acct -> do
-                MV.putMVar mvar (ps,ss)
+                MV.putMVar mvar (ps, ss, store)
                 return $ BSC.pack $ show $ Map.lookup acct bals
 
             ObserveAccounts -> do
-                MV.putMVar mvar (ps, ss)
+                MV.putMVar mvar (ps, ss, store)
                 return $ BSC.pack $ prettyLedger bals
 
-            Program term ->
+            CommandInputQuery rid' -> do
+                 MV.putMVar mvar (ps, ss, store)
+                 return $ BSC.pack $ show $ Map.lookup rid' store
+
+            Program input term -> do
                 case DTerm.evaluableHopliteTerm term of
                     Nothing -> do
-                      MV.putMVar mvar (ps, ss)
-                      return "Invalid Command or Program"
+                      MV.putMVar mvar (ps, ss, store)
+                      return $  BSC.pack $ "Invalid Command or Program" ++ (show term)
                     Just (DTerm.PolyF evaluableTerm) ->
                         case DEval.runExpr 10000 ps evaluableTerm of
                             Left err -> do
-                                MV.putMVar mvar (ps, ss)
+                                MV.putMVar mvar (ps, ss, store)
                                 return $ BSC.pack $ "Execution issue " ++ show err
                             Right (DEval.InterpreterOutput (DEval.InterpreterDiff _balsDiff ops)
                                                         nextPs) -> do
-                                MV.putMVar mvar (nextPs, ss)
+                                store' <- return $ Map.insert rid input store
+                                MV.putMVar mvar (nextPs, ss, store')
                                 return $ BSC.pack $ "Success"
                                         ++ "\n## Transaction Log ##\n" ++ unlines (prettyOpLog . snd <$> ops)
-                                        ++ "\n ## Previous Ledger ## " ++ prettyLedger bals
+                                        ++ "\n## Previous Ledger ## " ++ prettyLedger bals
                                         ++ "\n## New Ledger ##" ++ prettyLedger (balances nextPs)
 
             SwiftPayment s term ->
                 case DTerm.evaluableHopliteTerm term of
                     Nothing -> do
-                      MV.putMVar mvar (ps, ss)
+                      MV.putMVar mvar (ps, ss, store)
                       return "Invalid SwiftPayment Command"
                     Just (DTerm.PolyF evaluableTerm) ->
                         case DEval.runExpr 10000 ps evaluableTerm of
                             Left err -> do
-                                MV.putMVar mvar (ps, ss)
+                                MV.putMVar mvar (ps, ss, store)
                                 return $ BLC.toStrict $ encode $
                                     object [ "status" .= ("Failure" :: T.Text)
                                            , "reason" .= show err]
                             Right (DEval.InterpreterOutput (DEval.InterpreterDiff _balsDiff _ops)
                                                         nextPs) -> do
                                 nextSs <- return $ Map.insert (ps ^. DEval.persistentNextTxId) s ss
-                                MV.putMVar mvar (nextPs, nextSs)
+                                MV.putMVar mvar (nextPs, nextSs, store)
                                 (DEval.TransactionId tid) <- return $ (ps ^. DEval.persistentNextTxId)
                                 return $ BLC.toStrict $ encode $
                                     object [ "status" .= ("Success" :: T.Text)
@@ -120,7 +130,7 @@ runCommand env cmd' = do
                                            ]
 
             LedgerQueryCmd v -> do
-              MV.putMVar mvar (ps, ss)
+              MV.putMVar mvar (ps, ss, store)
               res <- return $ runQuery v (ps ^. DEval.persistentTxes, ss)
               return $ BLC.toStrict $ encodePretty res
 

--- a/src/Apps/Juno/Command.hs
+++ b/src/Apps/Juno/Command.hs
@@ -20,6 +20,7 @@ import Data.Aeson.Encode.Pretty (encodePretty)
 
 import Juno.Types (CommandEntry(..), CommandResult(..))
 import Juno.Types.Base (RequestId)
+import Juno.Types.Message.CMD
 import Schwifty.Swift.M105.Types (SWIFT)
 
 import Apps.Juno.Parser
@@ -43,8 +44,8 @@ setBalances :: Map.Map Text Rational -> DEval.PersistentState -> DEval.Persisten
 setBalances bals ps = ps { DEval._persistentBalances = bals }
 
 --JunoEnv:  MVar (State, Map(TX -> Swift))
-runCommand :: JunoEnv -> (CommandEntry, RequestId) -> IO CommandResult
-runCommand env (cmd', rid) = do
+runCommand :: JunoEnv -> Command -> IO CommandResult
+runCommand env Command{_cmdEntry = cmd'@_, _cmdRequestId = rid@_} = do
   mvar <- return $ getStateMVar env
   orgState@(ps, ss, store) <- MV.takeMVar mvar -- persistent s, swift, prog input store
   let bals = balances ps

--- a/src/Apps/Juno/JsonTypes.hs
+++ b/src/Apps/Juno/JsonTypes.hs
@@ -140,7 +140,8 @@ data PollPayloadRequest = PollPayloadRequest {
   } deriving (Eq, Generic, Show)
 
 instance ToJSON PollPayloadRequest where
-  toJSON (PollPayloadRequest payload' digest') = object ["payload" .= payload', "digest" .= digest']
+  toJSON (PollPayloadRequest payload' digest') = object ["payload" .= payload'
+                                                        , "digest" .= digest']
 instance FromJSON PollPayloadRequest where
   parseJSON (Object v) = PollPayloadRequest <$> v .: "payload"
                                             <*> v .: "digest"
@@ -328,3 +329,6 @@ mJsonBsToCommand bs = JSON.decode bs >>= \v ->
 
     mtransact (TransactBody code _) =
         BSC.pack $ T.unpack code
+
+
+--

--- a/src/Apps/Juno/Server.hs
+++ b/src/Apps/Juno/Server.hs
@@ -16,6 +16,6 @@ main = do
   -- shared on a node basis between API interface and protocol
   sharedCmdStatusMap <- initCommandMap
   let -- applyFn :: et -> IO rt
-      applyFn :: CommandEntry -> IO CommandResult
+      applyFn :: (CommandEntry, RequestId) -> IO CommandResult
       applyFn = runCommand stateVariable
   runJuno applyFn toCommands fromCommands sharedCmdStatusMap

--- a/src/Apps/Juno/Server.hs
+++ b/src/Apps/Juno/Server.hs
@@ -7,6 +7,7 @@ import Control.Concurrent.Chan.Unagi
 import Apps.Juno.Command
 import Juno.Spec.Simple
 import Juno.Types (CommandEntry, CommandResult, initCommandMap)
+import Juno.Types.Message.CMD (Command(..))
 
 -- | Runs a 'Raft nt String String mt'.
 main :: IO ()
@@ -16,6 +17,6 @@ main = do
   -- shared on a node basis between API interface and protocol
   sharedCmdStatusMap <- initCommandMap
   let -- applyFn :: et -> IO rt
-      applyFn :: (CommandEntry, RequestId) -> IO CommandResult
+      applyFn :: Command -> IO CommandResult
       applyFn = runCommand stateVariable
   runJuno applyFn toCommands fromCommands sharedCmdStatusMap

--- a/src/Juno/Consensus/Commit.hs
+++ b/src/Juno/Consensus/Commit.hs
@@ -67,7 +67,7 @@ applyCommand :: Monad m => UTCTime -> Command -> Raft m (NodeID, CommandResponse
 applyCommand tEnd cmd@Command{..} = do
   apply <- view (rs.applyLogEntry)
   logApplyLatency cmd
-  result <- apply _cmdEntry
+  result <- apply (_cmdEntry, _cmdRequestId)
   updateCmdStatusMap cmd result tEnd -- shared with the API and to query state
   replayMap %= Map.insert (_cmdClientId, getCmdSigOrInvariantError "applyCommand" cmd) (Just result)
   ((,) _cmdClientId) <$> makeCommandResponse tEnd cmd result

--- a/src/Juno/Consensus/Commit.hs
+++ b/src/Juno/Consensus/Commit.hs
@@ -67,7 +67,7 @@ applyCommand :: Monad m => UTCTime -> Command -> Raft m (NodeID, CommandResponse
 applyCommand tEnd cmd@Command{..} = do
   apply <- view (rs.applyLogEntry)
   logApplyLatency cmd
-  result <- apply (_cmdEntry, _cmdRequestId)
+  result <- apply cmd
   updateCmdStatusMap cmd result tEnd -- shared with the API and to query state
   replayMap %= Map.insert (_cmdClientId, getCmdSigOrInvariantError "applyCommand" cmd) (Just result)
   ((,) _cmdClientId) <$> makeCommandResponse tEnd cmd result

--- a/src/Juno/Spec/Simple.hs
+++ b/src/Juno/Spec/Simple.hs
@@ -97,7 +97,7 @@ simpleRaftSpec :: MonadIO m
                -> InChan (OutBoundMsg String ByteString)
                -> Bounded.OutChan Event
                -> Bounded.InChan Event
-               -> ((CommandEntry, RequestId) -> m CommandResult)
+               -> (Command -> m CommandResult)
                -> (NodeID -> String -> m ())
                -> (Metric -> m ())
                -> (MVar CommandMap -> RequestId -> CommandStatus -> m ())
@@ -223,7 +223,7 @@ updateCmdMapFn cmdMapMvar rid cmdStatus =
      )
     )
 
-runClient :: ((CommandEntry, RequestId) -> IO CommandResult) -> IO (RequestId, [CommandEntry]) -> CommandMVarMap -> IO ()
+runClient :: (Command -> IO CommandResult) -> IO (RequestId, [CommandEntry]) -> CommandMVarMap -> IO ()
 runClient applyFn getEntries cmdStatusMap' = do
   rconf <- getConfig
   me <- return $ nodeIDtoAddr $ rconf ^. nodeId
@@ -251,7 +251,7 @@ runClient applyFn getEntries cmdStatusMap' = do
 --   shared state between API and protocol: sharedCmdStatusMap
 --   comminication channel btw API and protocol:
 --   [API write/place command -> toCommands] [getApiCommands -> juno read/poll command]
-runJuno :: ((CommandEntry, RequestId) -> IO CommandResult) -> InChan (RequestId, [CommandEntry])
+runJuno :: (Command -> IO CommandResult) -> InChan (RequestId, [CommandEntry])
         -> OutChan (RequestId, [CommandEntry]) -> CommandMVarMap -> IO ()
 runJuno applyFn toCommands getApiCommands sharedCmdStatusMap = do
   rconf <- getConfig

--- a/src/Juno/Spec/Simple.hs
+++ b/src/Juno/Spec/Simple.hs
@@ -97,7 +97,7 @@ simpleRaftSpec :: MonadIO m
                -> InChan (OutBoundMsg String ByteString)
                -> Bounded.OutChan Event
                -> Bounded.InChan Event
-               -> (CommandEntry -> m CommandResult)
+               -> ((CommandEntry, RequestId) -> m CommandResult)
                -> (NodeID -> String -> m ())
                -> (Metric -> m ())
                -> (MVar CommandMap -> RequestId -> CommandStatus -> m ())
@@ -223,7 +223,7 @@ updateCmdMapFn cmdMapMvar rid cmdStatus =
      )
     )
 
-runClient :: (CommandEntry -> IO CommandResult) -> IO (RequestId, [CommandEntry]) -> CommandMVarMap -> IO ()
+runClient :: ((CommandEntry, RequestId) -> IO CommandResult) -> IO (RequestId, [CommandEntry]) -> CommandMVarMap -> IO ()
 runClient applyFn getEntries cmdStatusMap' = do
   rconf <- getConfig
   me <- return $ nodeIDtoAddr $ rconf ^. nodeId
@@ -251,7 +251,7 @@ runClient applyFn getEntries cmdStatusMap' = do
 --   shared state between API and protocol: sharedCmdStatusMap
 --   comminication channel btw API and protocol:
 --   [API write/place command -> toCommands] [getApiCommands -> juno read/poll command]
-runJuno :: (CommandEntry -> IO CommandResult) -> InChan (RequestId, [CommandEntry])
+runJuno :: ((CommandEntry, RequestId) -> IO CommandResult) -> InChan (RequestId, [CommandEntry])
         -> OutChan (RequestId, [CommandEntry]) -> CommandMVarMap -> IO ()
 runJuno applyFn toCommands getApiCommands sharedCmdStatusMap = do
   rconf <- getConfig

--- a/src/Juno/Types/Spec.hs
+++ b/src/Juno/Types/Spec.hs
@@ -69,7 +69,7 @@ data RaftSpec m = RaftSpec
   , _writeVotedFor    :: Maybe NodeID -> m ()
 
     -- ^ Function to apply a log entry to the state machine.
-  , _applyLogEntry    :: CommandEntry -> m CommandResult
+  , _applyLogEntry    :: (CommandEntry, RequestId) -> m CommandResult
 
     -- ^ Function to send a message to a node.
   , _sendMessage      :: NodeID -> ByteString -> m ()

--- a/src/Juno/Types/Spec.hs
+++ b/src/Juno/Types/Spec.hs
@@ -69,7 +69,7 @@ data RaftSpec m = RaftSpec
   , _writeVotedFor    :: Maybe NodeID -> m ()
 
     -- ^ Function to apply a log entry to the state machine.
-  , _applyLogEntry    :: (CommandEntry, RequestId) -> m CommandResult
+  , _applyLogEntry    :: Command -> m CommandResult
 
     -- ^ Function to send a message to a node.
   , _sendMessage      :: NodeID -> ByteString -> m ()

--- a/tests/ParserSpec.hs
+++ b/tests/ParserSpec.hs
@@ -4,6 +4,7 @@ module ParserSpec where
 import Test.Hspec
 import Apps.Juno.Parser
 import Data.Ratio
+import Data.Text as T
 import Juno.Hoplite.Term
 import Juno.Hoplite.Types (Literal(..))
 
@@ -31,17 +32,17 @@ testAdmins = do
 testHopperLite :: Spec
 testHopperLite = do
   it "does the thing" $ readHopper "transfer(foo->bar,101%100)" `shouldBe`
-         (Right (Program (Let "t" (PrimApp "transfer"
+         Right (Program T.empty (Let "t" (PrimApp "transfer"
                                    [ELit (LText "foo"),ELit (LText "bar"),
                                     ELit (LRational (101 % 100)),ELit (LText "cryptSig")])
-                          (V "t"))))
+                                 (V "t")))
 
 
 testTransmatic :: Spec
 testTransmatic = do
   it "does the stuff" $ readHopper "(#transfer \"foo\" \"bar\" (% 110 100) \"baz\")" `shouldBe`
-     Right (Program (PrimApp "transfer"
-                     [ELit (LText "foo"),
-                      ELit (LText "bar"),
-                      ELit (LRational (11 % 10)),
-                      ELit (LText "baz")]))
+     Right (Program  T.empty (PrimApp "transfer"
+                              [ELit (LText "foo"),
+                               ELit (LText "bar"),
+                               ELit (LRational (11 % 10)),
+                               ELit (LText "baz")]))


### PR DESCRIPTION
Added ability to optionally store data submitted with a Program. The data can be retrieved via the `RequestId`: `CommandInputQuery RequestId`.
Added endpoint `/api/juno/v1/transfer` for specified JSON:
`{ "payload": {
    "transfer":
      "acctFrom" : "000"
      "acctTo" : "000"
      "amount" : 230.00"
      "currency" : "USD"  
    , "data":
        { "mtmessage": "{data to save}"}
    }
}`
